### PR TITLE
fix(ci): fix gitleaks shallow clone - fetch full git history

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -408,6 +408,8 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history required for gitleaks commit-range diff
 
       - name: Gitleaks Scan
         uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Problem
```
fatal: ambiguous argument '...^..': unknown revision or path not in the working tree
failed to scan Git repository error="stderr is not empty"
```

Gitleaks scans commit ranges to find secret leaks, but `actions/checkout@v4` defaults to `fetch-depth: 1` (shallow clone). The parent commits needed for the diff don't exist.

## Fix
Added `fetch-depth: 0` to checkout in the secret-detect job to get full git history.

Refs: #27