### PR TITLE
fix(sca): patch embedded Tomcat CVEs by overriding to 10.1.55

### DIFF
--- a/vendnet/pom.xml
+++ b/vendnet/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<java.version>17</java.version>
+		<tomcat.version>10.1.55</tomcat.version>
 		<spotbugs.version>4.8.6.4</spotbugs.version>
 		<findsecbugs.version>1.13.0</findsecbugs.version>
 		<dependency-check.version>10.0.3</dependency-check.version>


### PR DESCRIPTION
CVE-2026-41293 (9.8), CVE-2026-43512 (9.8), CVE-2026-43515 (9.1), CVE-2026-43513 (7.5) all affect tomcat-embed-core =10.1.54. Overriding tomcat.version to 10.1.55 patches all four CVEs.

Closes #29