### PR TITLE
fix(ci): point SonarQube to persistent server at vs427:2226

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -243,7 +243,7 @@ jobs:
           path: vendnet/target/failsafe-reports/
 
   # ===========================================================================
-  # STAGE 6 — SonarQube Quality Gate (Local)
+  # STAGE 6 — SonarQube Quality Gate (Persistent Server at vs427)
   # Covers: US-SAST-003
   # Acceptance: 0 new Critical/Blocker, coverage >=80%, duplication <=3%
   # ===========================================================================
@@ -251,12 +251,6 @@ jobs:
     name: SonarQube - Quality Gate
     runs-on: ubuntu-latest
     needs: [build, sast, sca]
-    services:
-      sonarqube:
-        image: sonarqube:lts-community
-        ports: ['9000:9000']
-        env:
-          SONAR_ES_BOOTSTRAP_CHECKS_DISABLE: 'true'
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
@@ -267,31 +261,20 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Wait for SonarQube
-        run: |
-          for i in $(seq 1 90); do
-            STATUS=$(curl -s -u admin:admin -o /dev/null -w "%{http_code}" http://localhost:9000/api/system/status 2>/dev/null || echo "000")
-            if [ "$STATUS" = "200" ]; then
-              echo "SonarQube is UP after $((i * 2))s"
-              break
-            fi
-            sleep 2
-          done
-
       - name: SonarQube Scan
-        run: ./mvnw -B verify sonar:sonar -Dsonar.host.url=http://localhost:9000 -Dsonar.login=admin -Dsonar.password=admin
+        run: ./mvnw -B verify sonar:sonar -Dsonar.host.url=http://vs-gate.dei.isep.ipp.pt:10427 -Dsonar.token=${{ secrets.SONAR_TOKEN }}
         working-directory: vendnet
 
       - name: SonarQube Quality Gate
         run: |
           TASK_ID=$(grep ceTaskId vendnet/target/sonar/report-task.txt | cut -d= -f2)
           for i in $(seq 1 30); do
-            STATUS=$(curl -sS -u admin:admin "http://localhost:9000/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
+            STATUS=$(curl -sS -u "${{ secrets.SONAR_TOKEN }}:" "http://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
             if [ "$STATUS" = "SUCCESS" ]; then break; fi
             sleep 2
           done
-          ANALYSIS_ID=$(curl -sS -u admin:admin "http://localhost:9000/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['analysisId'])" 2>/dev/null)
-          QG_STATUS=$(curl -sS -u admin:admin "http://localhost:9000/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
+          ANALYSIS_ID=$(curl -sS -u "${{ secrets.SONAR_TOKEN }}:" "http://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['analysisId'])" 2>/dev/null)
+          QG_STATUS=$(curl -sS -u "${{ secrets.SONAR_TOKEN }}:" "http://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
           echo "Quality Gate: ${QG_STATUS}"
           if [ "$QG_STATUS" != "OK" ]; then
             echo "::error::Quality Gate FAILED: ${QG_STATUS}"


### PR DESCRIPTION
Replaced ephemeral service container with external persistent SonarQube instance on vs427.dei.isep.ipp.pt (port 2226 -> vs-gate:10427). Uses SONAR_TOKEN secret for authentication.

Closes #28