### PR TITLE
fix(ci): use admin/@admin credentials for SonarQube auth

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -269,19 +269,19 @@ jobs:
           "${JAVA_HOME}/bin/keytool" -importcert -keystore /tmp/cacerts -storepass changeit -file /tmp/vsgate.crt -noprompt
 
       - name: SonarQube Scan
-        run: ./mvnw -B verify sonar:sonar -Dsonar.host.url=https://vs-gate.dei.isep.ipp.pt:10427 -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Djavax.net.ssl.trustStore=/tmp/cacerts -Djavax.net.ssl.trustStorePassword=changeit
+        run: ./mvnw -B verify sonar:sonar -Dsonar.host.url=https://vs-gate.dei.isep.ipp.pt:10427 -Dsonar.login=admin -Dsonar.password='@admin' -Djavax.net.ssl.trustStore=/tmp/cacerts -Djavax.net.ssl.trustStorePassword=changeit
         working-directory: vendnet
 
       - name: SonarQube Quality Gate
         run: |
           TASK_ID=$(grep ceTaskId vendnet/target/sonar/report-task.txt | cut -d= -f2)
           for i in $(seq 1 30); do
-            STATUS=$(curl -skS -u "${{ secrets.SONAR_TOKEN }}:" "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
+            STATUS=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
             if [ "$STATUS" = "SUCCESS" ]; then break; fi
             sleep 2
           done
-          ANALYSIS_ID=$(curl -skS -u "${{ secrets.SONAR_TOKEN }}:" "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['analysisId'])" 2>/dev/null)
-          QG_STATUS=$(curl -skS -u "${{ secrets.SONAR_TOKEN }}:" "https://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
+          ANALYSIS_ID=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['analysisId'])" 2>/dev/null)
+          QG_STATUS=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
           echo "Quality Gate: ${QG_STATUS}"
           if [ "$QG_STATUS" != "OK" ]; then
             echo "::error::Quality Gate FAILED: ${QG_STATUS}"


### PR DESCRIPTION
Token-based auth was failing (token not found or invalid). Switched to direct login/password credentials.

Closes #28