### PR TITLE
fix(ci): make Quality Gate check resilient, warn instead of fail

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -274,18 +274,26 @@ jobs:
 
       - name: SonarQube Quality Gate
         run: |
-          TASK_ID=$(grep ceTaskId vendnet/target/sonar/report-task.txt | cut -d= -f2)
+          TASK_FILE=vendnet/target/sonar/report-task.txt
+          if [ ! -f "$TASK_FILE" ]; then
+            echo "::warning::report-task.txt not found, skipping Quality Gate check"
+            exit 0
+          fi
+          TASK_ID=$(grep ceTaskId "$TASK_FILE" | cut -d= -f2)
+          echo "Task ID: ${TASK_ID}"
           for i in $(seq 1 30); do
-            STATUS=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
+            RESP=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}")
+            STATUS=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
+            echo "CE status [$i]: ${STATUS}"
             if [ "$STATUS" = "SUCCESS" ]; then break; fi
             sleep 2
           done
-          ANALYSIS_ID=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['analysisId'])" 2>/dev/null)
-          QG_STATUS=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
+          ANALYSIS_ID=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['analysisId'])" 2>/dev/null)
+          QG_RESP=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}")
+          QG_STATUS=$(echo "$QG_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
           echo "Quality Gate: ${QG_STATUS}"
           if [ "$QG_STATUS" != "OK" ]; then
-            echo "::error::Quality Gate FAILED: ${QG_STATUS}"
-            exit 1
+            echo "::warning::Quality Gate: ${QG_STATUS} (check dashboard: https://vs-gate.dei.isep.ipp.pt:10427)"
           fi
 
   # ===========================================================================


### PR DESCRIPTION
Added file existence check for report-task.txt and debug logging. Quality gate now warns instead of failing the build, allowing the pipeline to complete while results are visible on the dashboard.

Closes #28