### PR TITLE
fix(ci): fix semgrep config — remove nonexistent p/spring and .semgrep/

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Semgrep Scan
         uses: returntocorp/semgrep-action@v1
         with:
-          config: p/java p/spring p/secrets .semgrep/
+          config: p/java p/secrets
 
       - name: Check Semgrep SARIF exists
         id: semgrep-sarif


### PR DESCRIPTION
p/spring returns 404 from semgrep.dev and .semgrep/ directory doesn't exist. p/java already covers Java and Spring security rules.

Closes #28