### PR TITLE
fix(ci): increase QG timeout to 180s, add error resilience

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -268,41 +268,9 @@ jobs:
           echo | openssl s_client -connect vs-gate.dei.isep.ipp.pt:10427 -servername vs-gate.dei.isep.ipp.pt 2>/dev/null | openssl x509 -out /tmp/vsgate.crt
           "${JAVA_HOME}/bin/keytool" -importcert -keystore /tmp/cacerts -storepass changeit -file /tmp/vsgate.crt -noprompt
 
-      - name: SonarQube Scan
-        run: ./mvnw -B verify sonar:sonar -Dsonar.host.url=https://vs-gate.dei.isep.ipp.pt:10427 -Dsonar.login=admin -Dsonar.password='@admin' -Djavax.net.ssl.trustStore=/tmp/cacerts -Djavax.net.ssl.trustStorePassword=changeit
+      - name: SonarQube Scan + Quality Gate
+        run: ./mvnw -B verify sonar:sonar -Dsonar.host.url=https://vs-gate.dei.isep.ipp.pt:10427 -Dsonar.login=admin -Dsonar.password='@admin' -Dsonar.qualitygate.wait=true -Dsonar.qualitygate.timeout=300 -Djavax.net.ssl.trustStore=/tmp/cacerts -Djavax.net.ssl.trustStorePassword=changeit
         working-directory: vendnet
-
-      - name: SonarQube Quality Gate
-        run: |
-          set +e
-          TASK_FILE=vendnet/target/sonar/report-task.txt
-          if [ ! -f "$TASK_FILE" ]; then
-            echo "::warning::report-task.txt not found, skipping Quality Gate check"
-            exit 0
-          fi
-          TASK_ID=$(grep ceTaskId "$TASK_FILE" | cut -d= -f2)
-          echo "Task ID: ${TASK_ID}"
-          for i in $(seq 1 90); do
-            RESP=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}")
-            STATUS=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
-            echo "CE status [$i]: ${STATUS}"
-            if [ "$STATUS" = "SUCCESS" ]; then break; fi
-            if [ "$STATUS" = "FAILED" ] || [ "$STATUS" = "CANCELED" ]; then
-              echo "::error::CE task ${STATUS}"
-              exit 1
-            fi
-            sleep 2
-          done
-          QG_STATUS="TIMEOUT"
-          ANALYSIS_ID=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin)['task']; print(d.get('analysisId',''))" 2>/dev/null)
-          if [ -n "$ANALYSIS_ID" ]; then
-            QG_RESP=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}")
-            QG_STATUS=$(echo "$QG_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
-          fi
-          echo "Quality Gate: ${QG_STATUS}"
-          if [ "$QG_STATUS" != "OK" ]; then
-            echo "::warning::Quality Gate: ${QG_STATUS} (check dashboard: https://vs-gate.dei.isep.ipp.pt:10427)"
-          fi
 
   # ===========================================================================
   # STAGE 7 — DAST: OWASP ZAP

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -274,6 +274,7 @@ jobs:
 
       - name: SonarQube Quality Gate
         run: |
+          set +e
           TASK_FILE=vendnet/target/sonar/report-task.txt
           if [ ! -f "$TASK_FILE" ]; then
             echo "::warning::report-task.txt not found, skipping Quality Gate check"
@@ -281,16 +282,23 @@ jobs:
           fi
           TASK_ID=$(grep ceTaskId "$TASK_FILE" | cut -d= -f2)
           echo "Task ID: ${TASK_ID}"
-          for i in $(seq 1 30); do
+          for i in $(seq 1 90); do
             RESP=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/ce/task?id=${TASK_ID}")
             STATUS=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['status'])" 2>/dev/null || echo "PENDING")
             echo "CE status [$i]: ${STATUS}"
             if [ "$STATUS" = "SUCCESS" ]; then break; fi
+            if [ "$STATUS" = "FAILED" ] || [ "$STATUS" = "CANCELED" ]; then
+              echo "::error::CE task ${STATUS}"
+              exit 1
+            fi
             sleep 2
           done
-          ANALYSIS_ID=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['task']['analysisId'])" 2>/dev/null)
-          QG_RESP=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}")
-          QG_STATUS=$(echo "$QG_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
+          QG_STATUS="TIMEOUT"
+          ANALYSIS_ID=$(echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin)['task']; print(d.get('analysisId',''))" 2>/dev/null)
+          if [ -n "$ANALYSIS_ID" ]; then
+            QG_RESP=$(curl -skS -u 'admin:@admin' "https://vs-gate.dei.isep.ipp.pt:10427/api/qualitygates/project_status?analysisId=${ANALYSIS_ID}")
+            QG_STATUS=$(echo "$QG_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['projectStatus']['status'])" 2>/dev/null || echo "ERROR")
+          fi
           echo "Quality Gate: ${QG_STATUS}"
           if [ "$QG_STATUS" != "OK" ]; then
             echo "::warning::Quality Gate: ${QG_STATUS} (check dashboard: https://vs-gate.dei.isep.ipp.pt:10427)"


### PR DESCRIPTION
Extended CE task polling from 60s to 180s. Added set +e for bash, dict.get for missing analysisId, and FAILED/CANCELED detection.

Closes #28