### PR TITLE
fix(ci): add chmod a+w to .zap/reports for ZAP container write access

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -338,6 +338,7 @@ jobs:
       - name: ZAP Baseline Scan - Public Surface
         run: |
           mkdir -p .zap/reports
+          chmod -R a+w .zap/reports
           docker run --rm --network host \
             -v ${{ github.workspace }}/.zap:/zap/wrk \
             ghcr.io/zaproxy/zaproxy:stable \
@@ -358,6 +359,7 @@ jobs:
       - name: ZAP Authenticated Scan - Protected Endpoints
         run: |
           mkdir -p .zap/reports
+          chmod -R a+w .zap/reports
           docker run --rm --network host \
             -v ${{ github.workspace }}/.zap:/zap/wrk \
             ghcr.io/zaproxy/zaproxy:stable \


### PR DESCRIPTION
The ZAP Docker container runs as zap user but the mounted .zap/reports directory is owned by the runner user. chmod -R a+w allows the container to write scan reports (html, md, xml).

Closes #34