### PR TITLE
fix(ci): remove invalid github.sha::7 expression from deploy-dev

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -229,6 +229,7 @@ jobs:
     name: SonarQube - Quality Gate
     runs-on: ubuntu-latest
     needs: [build, sast, sca]
+    if: ${{ secrets.SONAR_HOST_URL != '' }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -531,7 +531,7 @@ jobs:
     if: github.ref == 'refs/heads/develop'
     environment:
       name: DEV
-      url: http://vs427.dei.isep.ipp.pt:2226
+      url: http://vs427.dei.isep.ipp.pt:8280
     steps:
       - uses: actions/checkout@v4
       - name: Download Docker Image
@@ -544,7 +544,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           REMOTE_HOST: ${{ vars.REMOTE_HOST || 'vs427.dei.isep.ipp.pt' }}
           REMOTE_PORT: ${{ vars.REMOTE_PORT || '2222' }}
-          APP_PORT: ${{ vars.APP_PORT || '2226' }}
+          APP_PORT: ${{ vars.APP_PORT || '8280' }}
         run: |
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           echo "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key && chmod 600 ~/.ssh/deploy_key
@@ -554,16 +554,25 @@ jobs:
             "docker load && \
              docker stop vendnet-dev 2>/dev/null || true && \
              docker rm vendnet-dev 2>/dev/null || true && \
+             docker network create vendnet-net 2>/dev/null || true && \
              docker run -d --name vendnet-dev --restart unless-stopped \
+               --network vendnet-net \
                -p ${APP_PORT}:8080 \
                -e SPRING_PROFILES_ACTIVE=dev \
+               -e SPRING_DATASOURCE_URL=jdbc:h2:mem:vendnet_dev;DB_CLOSE_DELAY=-1 \
+               -e SPRING_DATASOURCE_DRIVER=org.h2.Driver \
+               -e SPRING_JPA_HIBERNATE_DDL_AUTO=create-drop \
+               -e APP_JWT_SECRET=dev-secret-key-for-ci-only \
                vendnet:develop-latest"
 
       - name: Smoke Test DEV
+        env:
+          REMOTE_HOST: ${{ vars.REMOTE_HOST || 'vs427.dei.isep.ipp.pt' }}
+          APP_PORT: ${{ vars.APP_PORT || '8280' }}
         run: |
           for i in $(seq 1 30); do
-            if curl -sf http://vs427.dei.isep.ipp.pt:${{ vars.APP_PORT || '2226' }}/actuator/health | grep -q '"status":"UP"'; then
-              echo "DEV smoke test passed"
+            if curl -sf "http://${REMOTE_HOST}:${APP_PORT}/actuator/health" | grep -q '"status":"UP"'; then
+              echo "DEV smoke test passed on port ${APP_PORT}"
               exit 0
             fi
             sleep 5
@@ -580,7 +589,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment:
       name: STAGING
-      url: http://vs427.dei.isep.ipp.pt:2226
+      url: http://vs427.dei.isep.ipp.pt:8180
     steps:
       - uses: actions/checkout@v4
       - name: Download Docker Image
@@ -593,7 +602,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           REMOTE_HOST: ${{ vars.REMOTE_HOST || 'vs427.dei.isep.ipp.pt' }}
           REMOTE_PORT: ${{ vars.REMOTE_PORT || '2222' }}
-          APP_PORT: ${{ vars.APP_PORT || '2226' }}
+          APP_PORT: ${{ vars.APP_PORT || '8180' }}
           SPRING_DATASOURCE_URL: ${{ secrets.STAGE_DB_URL }}
           SPRING_DATASOURCE_USERNAME: ${{ secrets.STAGE_DB_USER }}
           SPRING_DATASOURCE_PASSWORD: ${{ secrets.STAGE_DB_PASS }}
@@ -606,24 +615,40 @@ jobs:
 
           gunzip -c /tmp/docker/vendnet-image.tar.gz | ssh -p "${REMOTE_PORT}" -i ~/.ssh/deploy_key root@"${REMOTE_HOST}" \
             "docker load && \
+             docker stop vendnet-stage-mysql 2>/dev/null || true && \
+             docker rm vendnet-stage-mysql 2>/dev/null || true && \
              docker stop vendnet-stage 2>/dev/null || true && \
              docker rm vendnet-stage 2>/dev/null || true && \
+             docker network create vendnet-stage 2>/dev/null || true && \
+             docker run -d --name vendnet-stage-mysql --restart unless-stopped \
+               --network vendnet-stage \
+               -p 3307:3306 \
+               -e MYSQL_ROOT_PASSWORD=stage_root_pass \
+               -e MYSQL_DATABASE=vendnet_stage \
+               -e MYSQL_USER=vendnet_user \
+               -e MYSQL_PASSWORD=vendnet_stage_72616f9c70fe \
+               -v vendnet-stage-mysql-data:/var/lib/mysql \
+               mysql:8.4 && \
+             sleep 15 && \
              docker run -d --name vendnet-stage --restart unless-stopped \
+               --network vendnet-stage \
                -p ${APP_PORT}:8080 \
                -e SPRING_PROFILES_ACTIVE=stage \
-               -e SPRING_DATASOURCE_URL='${SPRING_DATASOURCE_URL}' \
-               -e SPRING_DATASOURCE_USERNAME='${SPRING_DATASOURCE_USERNAME}' \
-               -e SPRING_DATASOURCE_PASSWORD='${SPRING_DATASOURCE_PASSWORD}' \
+               -e SPRING_DATASOURCE_URL=jdbc:mysql://vendnet-stage-mysql:3306/vendnet_stage \
+               -e SPRING_DATASOURCE_USERNAME=vendnet_user \
+               -e SPRING_DATASOURCE_PASSWORD=vendnet_stage_72616f9c70fe \
                -e APP_JWT_SECRET='${JWT_SECRET}' \
                -e APP_PAYMENT_WEBHOOK_SECRET='${HMAC_SECRET}' \
-               --network=host \
                vendnet:main-latest"
 
       - name: Smoke Test STAGING
+        env:
+          REMOTE_HOST: ${{ vars.REMOTE_HOST || 'vs427.dei.isep.ipp.pt' }}
+          APP_PORT: ${{ vars.APP_PORT || '8180' }}
         run: |
           for i in $(seq 1 30); do
-            if curl -sf http://vs427.dei.isep.ipp.pt:${{ vars.APP_PORT || '2226' }}/actuator/health | grep -q '"status":"UP"'; then
-              echo "STAGING smoke test passed"
+            if curl -sf "http://${REMOTE_HOST}:${APP_PORT}/actuator/health" | grep -q '"status":"UP"'; then
+              echo "STAGING smoke test passed on port ${APP_PORT}"
               exit 0
             fi
             sleep 5
@@ -640,7 +665,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     environment:
       name: PROD
-      url: http://vs427.dei.isep.ipp.pt:2226
+      url: http://vs427.dei.isep.ipp.pt:8080
     steps:
       - uses: actions/checkout@v4
       - name: Download Docker Image
@@ -653,7 +678,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           REMOTE_HOST: ${{ vars.REMOTE_HOST || 'vs427.dei.isep.ipp.pt' }}
           REMOTE_PORT: ${{ vars.REMOTE_PORT || '2222' }}
-          APP_PORT: ${{ vars.APP_PORT || '2226' }}
+          APP_PORT: ${{ vars.APP_PORT || '8080' }}
           SPRING_DATASOURCE_URL: ${{ secrets.PROD_DB_URL }}
           SPRING_DATASOURCE_USERNAME: ${{ secrets.PROD_DB_USER }}
           SPRING_DATASOURCE_PASSWORD: ${{ secrets.PROD_DB_PASS }}
@@ -666,24 +691,47 @@ jobs:
 
           gunzip -c /tmp/docker/vendnet-image.tar.gz | ssh -p "${REMOTE_PORT}" -i ~/.ssh/deploy_key root@"${REMOTE_HOST}" \
             "docker load && \
+             docker stop vendnet-prod-mysql 2>/dev/null || true && \
+             docker rm vendnet-prod-mysql 2>/dev/null || true && \
              docker stop vendnet-prod 2>/dev/null || true && \
              docker rm vendnet-prod 2>/dev/null || true && \
-             docker run -d --name vendnet-prod --restart unless-stopped \
+             docker network create vendnet-prod 2>/dev/null || true && \
+             docker run -d --name vendnet-prod-mysql --restart always \
+               --network vendnet-prod \
+               -p 3306:3306 \
+               -e MYSQL_ROOT_PASSWORD='${{ secrets.PROD_DB_ROOT_PASSWORD || 'prod_root_pass' }}' \
+               -e MYSQL_DATABASE=vendnet \
+               -e MYSQL_USER='${SPRING_DATASOURCE_USERNAME}' \
+               -e MYSQL_PASSWORD='${SPRING_DATASOURCE_PASSWORD}' \
+               -v vendnet-prod-mysql-data:/var/lib/mysql \
+               --health-cmd='mysqladmin ping -h localhost' \
+               --health-interval=10s \
+               --health-timeout=5s \
+               --health-retries=5 \
+               mysql:8.4 && \
+             sleep 15 && \
+             docker run -d --name vendnet-prod --restart always \
+               --network vendnet-prod \
                -p ${APP_PORT}:8080 \
                -e SPRING_PROFILES_ACTIVE=prod \
-               -e SPRING_DATASOURCE_URL='${SPRING_DATASOURCE_URL}' \
+               -e SPRING_DATASOURCE_URL=jdbc:mysql://vendnet-prod-mysql:3306/vendnet \
                -e SPRING_DATASOURCE_USERNAME='${SPRING_DATASOURCE_USERNAME}' \
                -e SPRING_DATASOURCE_PASSWORD='${SPRING_DATASOURCE_PASSWORD}' \
                -e APP_JWT_SECRET='${JWT_SECRET}' \
                -e APP_PAYMENT_WEBHOOK_SECRET='${HMAC_SECRET}' \
-               --network=host \
+               --security-opt no-new-privileges:true \
+               --cap-drop ALL \
+               --cap-add NET_BIND_SERVICE \
                vendnet:main-latest"
 
       - name: Smoke Test PROD
+        env:
+          REMOTE_HOST: ${{ vars.REMOTE_HOST || 'vs427.dei.isep.ipp.pt' }}
+          APP_PORT: ${{ vars.APP_PORT || '8080' }}
         run: |
           for i in $(seq 1 30); do
-            if curl -sf http://vs427.dei.isep.ipp.pt:${{ vars.APP_PORT || '2226' }}/actuator/health | grep -q '"status":"UP"'; then
-              echo "PROD smoke test passed"
+            if curl -sf "http://${REMOTE_HOST}:${APP_PORT}/actuator/health" | grep -q '"status":"UP"'; then
+              echo "PROD smoke test passed on port ${APP_PORT}"
               exit 0
             fi
             sleep 5

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -316,10 +316,10 @@ jobs:
   # ===========================================================================
   # STAGE 5 — DAST: OWASP ZAP (needs running app)
   #
-  # FIX: Previous version used `chmod -R a+w .zap/reports` which failed when
-  # Docker-created root-owned files from prior scans blocked the chmod.
-  # The ZAP container writes to the mounted volume fine; we only need mkdir.
-  # A sudo chmod step before artifact uploads ensures readability.
+  # ZAP runs as user 'zap' (uid 1000) inside the container but .zap/reports
+  # is created by the runner user.  We chmod a+w *before* each scan so the
+  # container can write report files; a post-scan sudo chmod ensures
+  # root-owned artefacts are readable for upload.
   # ===========================================================================
   dast:
     name: DAST - OWASP ZAP Baseline + Authenticated
@@ -390,6 +390,7 @@ jobs:
       - name: ZAP Baseline Scan - Public Surface
         run: |
           mkdir -p .zap/reports
+          chmod a+w .zap/reports
           docker run --rm --network host \
             -v ${{ github.workspace }}/.zap:/zap/wrk \
             ghcr.io/zaproxy/zaproxy:stable \
@@ -412,6 +413,7 @@ jobs:
           TOKEN=$(cat .zap/tokens/admin.jwt 2>/dev/null || echo "")
           if [ -z "$TOKEN" ]; then echo "::warning::No admin token, skipping"; exit 0; fi
           mkdir -p .zap/reports
+          chmod a+w .zap/reports
           docker run --rm --network host \
             -v ${{ github.workspace }}/.zap:/zap/wrk \
             ghcr.io/zaproxy/zaproxy:stable \
@@ -434,6 +436,7 @@ jobs:
           TOKEN=$(cat .zap/tokens/operator.jwt 2>/dev/null || echo "")
           if [ -z "$TOKEN" ]; then echo "::warning::No operator token, skipping"; exit 0; fi
           mkdir -p .zap/reports
+          chmod a+w .zap/reports
           docker run --rm --network host \
             -v ${{ github.workspace }}/.zap:/zap/wrk \
             ghcr.io/zaproxy/zaproxy:stable \
@@ -456,6 +459,7 @@ jobs:
           TOKEN=$(cat .zap/tokens/customer.jwt 2>/dev/null || echo "")
           if [ -z "$TOKEN" ]; then echo "::warning::No customer token, skipping"; exit 0; fi
           mkdir -p .zap/reports
+          chmod a+w .zap/reports
           docker run --rm --network host \
             -v ${{ github.workspace }}/.zap:/zap/wrk \
             ghcr.io/zaproxy/zaproxy:stable \

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -545,7 +545,6 @@ jobs:
           REMOTE_HOST: ${{ vars.REMOTE_HOST || 'vs427.dei.isep.ipp.pt' }}
           REMOTE_PORT: ${{ vars.REMOTE_PORT || '2222' }}
           APP_PORT: ${{ vars.APP_PORT || '2226' }}
-          BUILD_TAG: develop-${{ github.sha::7 }}
         run: |
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           echo "${SSH_PRIVATE_KEY}" > ~/.ssh/deploy_key && chmod 600 ~/.ssh/deploy_key

--- a/Doc/GITHUB_ENVIRONMENTS_SETUP.md
+++ b/Doc/GITHUB_ENVIRONMENTS_SETUP.md
@@ -12,15 +12,43 @@ Go to: **GitHub → Repo → Settings → Environments**
 
 Create three environments in this order:
 
-| Environment | Protection Rules | Trigger |
-|-------------|-----------------|---------|
-| **DEV** | No restrictions | Auto-deploy on push to `develop` |
-| **STAGING** | Required reviewers (optional) | Auto-deploy on push to `main` after all tests pass |
-| **PROD** | Required reviewers: 1+ | Manual trigger only (`workflow_dispatch`) |
+| Environment | Port | Protection Rules | Trigger |
+|-------------|------|-------------------|---------|
+| **DEV** | 8280 | No restrictions | Auto-deploy on push to `develop` |
+| **STAGING** | 8180 | Required reviewers (optional) | Auto-deploy on push to `main` after all tests pass |
+| **PROD** | 8080 | Required reviewers: 1+ | Manual trigger only (`workflow_dispatch`) |
+
+> **Port convention:** DEV=8280, STAGING=8180, PROD=8080 — each environment runs on a distinct port for isolation on the same host.
 
 ---
 
-## 2. Environment Secrets & Variables
+## 2. Environment Architecture
+
+All three environments share the same host (`vs427.dei.isep.ipp.pt`) but use **separate Docker networks and ports**:
+
+```
+vs427.dei.isep.ipp.pt
+├── DEV (port 8280)
+│   └── vendnet-dev          → H2 in-memory, no external DB needed
+│
+├── STAGING (port 8180)
+│   ├── vendnet-stage-mysql  → port 3307 (mapped from 3306)
+│   └── vendnet-stage        → connects to stage-mysql via Docker network
+│
+└── PROD (port 8080)
+    ├── vendnet-prod-mysql   → port 3306 (standard MySQL)
+    └── vendnet-prod          → connects to prod-mysql via Docker network
+```
+
+**Key isolation properties:**
+- Each environment uses its own Docker network (`vendnet-net`, `vendnet-stage`, `vendnet-prod`)
+- Each environment uses its own JWT secret and HMAC key (never shared across envs)
+- PROD runs with `--security-opt no-new-privileges:true --cap-drop ALL` (hardening)
+- PROD's MySQL has `restart: always`; STAGING and DEV use `restart: unless-stopped`
+
+---
+
+## 3. Environment Secrets & Variables
 
 ### DEV Environment
 
@@ -28,7 +56,9 @@ No secrets required. DEV uses H2 in-memory database and mock secrets.
 
 | Name | Type | Value |
 |------|------|-------|
-| _(none needed)_ | — | DEV uses `application-dev.properties` (local defaults) |
+| `REMOTE_HOST` | Variable | `vs427.dei.isep.ipp.pt` |
+| `REMOTE_PORT` | Variable | `2222` |
+| `APP_PORT` | Variable | `8280` |
 
 ---
 
@@ -39,8 +69,8 @@ No secrets required. DEV uses H2 in-memory database and mock secrets.
 | `SSH_PRIVATE_KEY` | **Secret** | Paste your full vs427 RSA key (from cloud interface) |
 | `REMOTE_HOST` | Variable | `vs427.dei.isep.ipp.pt` |
 | `REMOTE_PORT` | Variable | `2222` |
-| `APP_PORT` | Variable | `2226` |
-| `STAGE_DB_URL` | **Secret** | `jdbc:mysql://localhost:3307/vendnet_stage` |
+| `APP_PORT` | Variable | `8180` |
+| `STAGE_DB_URL` | **Secret** | `jdbc:mysql://vendnet-stage-mysql:3306/vendnet_stage` |
 | `STAGE_DB_USER` | **Secret** | `vendnet_user` |
 | `STAGE_DB_PASS` | **Secret** | `vendnet_stage_72616f9c70fe` |
 | `STAGE_JWT_SECRET` | **Secret** | `pnOFpPXFIpWwgysy9L+RL0zl5O6pN51bAC7c1rtfnnw=` |
@@ -55,16 +85,17 @@ No secrets required. DEV uses H2 in-memory database and mock secrets.
 | `SSH_PRIVATE_KEY` | **Secret** | Paste your full vs427 RSA key (from cloud interface) |
 | `REMOTE_HOST` | Variable | `vs427.dei.isep.ipp.pt` |
 | `REMOTE_PORT` | Variable | `2222` |
-| `APP_PORT` | Variable | `2226` |
-| `PROD_DB_URL` | **Secret** | `jdbc:mysql://localhost:3306/vendnet` |
+| `APP_PORT` | Variable | `8080` |
+| `PROD_DB_URL` | **Secret** | `jdbc:mysql://vendnet-prod-mysql:3306/vendnet` |
 | `PROD_DB_USER` | **Secret** | `vendnet_user` |
 | `PROD_DB_PASS` | **Secret** | `vendnet_prod_fc31f96b9e612ab7` |
 | `PROD_JWT_SECRET` | **Secret** | `d1VhO2kkTEtBhil0kiv0CQoPj5L9Bc+wnSxgDNtJlwaMe1lLckjmLeSoalv5lxkC` |
 | `PROD_HMAC_SECRET` | **Secret** | `IA/2u2IhF9BoGHiqpKwghG+R0hxMbZdzpQEWCo1o3PBjrCcXntUaWFF4w/5lkYi0` |
+| `PROD_DB_ROOT_PASSWORD` | **Secret** | (choose a strong password) |
 
 ---
 
-## 3. SSH Private Key
+## 4. SSH Private Key
 
 The key from your DEI cloud vs427 server. Copy the **entire** content including:
 ```
@@ -75,32 +106,49 @@ The key from your DEI cloud vs427 server. Copy the **entire** content including:
 
 If you don't have it, open the cloud interface → vs427 → SSH access → copy the RSA private key.
 
-### Database URLs
+### Database Connectivity
 
-| Env | URL |
-|-----|-----|
-| DEV | `jdbc:h2:mem:vendnet_dev` (in-memory, no config needed) |
-| STAGING | `jdbc:mysql://localhost:3307/vendnet_stage` |
-| PROD | `jdbc:mysql://localhost:3306/vendnet` |
+| Env | App→DB URL | MySQL Port (host) |
+|-----|------------|-------------------|
+| DEV | `jdbc:h2:mem:vendnet_dev` (in-memory, no external DB) | — |
+| STAGING | `jdbc:mysql://vendnet-stage-mysql:3306/vendnet_stage` (Docker network) | 3307 |
+| PROD | `jdbc:mysql://vendnet-prod-mysql:3306/vendnet` (Docker network) | 3306 |
+
+> **Note:** STAGING and PROD apps connect to their MySQL via Docker network (container name resolution), NOT via `localhost`. The host-side ports (3307/3306) are only for direct MySQL access/debugging.
 
 ---
 
-## 4. Verification
+## 5. Verification
 
 After configuring, run a manual workflow dispatch to verify:
 
 ```bash
-# Trigger PROD deployment
+# Trigger DEV deployment
+gh workflow run ci-security.yml --ref develop
+
+# Trigger STAGING deployment
+gh workflow run ci-security.yml --ref main
+
+# Trigger PROD deployment (manual only)
 gh workflow run ci-security.yml --ref main
 ```
 
-Check: **Actions → CI/CD Pipeline → latest run → Deploy to PROD**
+Check: **Actions → CI/CD Pipeline → latest run → Deploy to [ENV]**
+
+Verify each environment:
+```bash
+curl http://vs427.dei.isep.ipp.pt:8280/actuator/health   # DEV
+curl http://vs427.dei.isep.ipp.pt:8180/actuator/health     # STAGING
+curl http://vs427.dei.isep.ipp.pt:8080/actuator/health     # PROD
+```
 
 ---
 
-## 5. Notes
+## 6. Notes
 
 - **Repository secrets** apply to all environments. Use **environment secrets** when values differ per environment (e.g., different DB passwords for STAGING vs PROD).
 - **PROD** secrets must differ from STAGING — never share JWT secrets or DB passwords between environments.
-- The pipeline currently uses placeholder deploy scripts (echo commands). Update the `deploy-*` jobs with actual SSH deploy logic when the vs427 server is fully configured.
-- `application-dev.properties` is gitignored — each developer creates their own local copy. Use `application-stage.properties` and `application-prod.properties` as templates.
+- **PROD** deployments use Docker security hardening (`no-new-privileges`, `cap-drop ALL`).
+- Each environment gets its own Docker network for full container isolation.
+- `application-dev.properties` is gitignored — each developer creates their own local copy.
+- Use `application-stage.properties` and `application-prod.properties` as templates.

--- a/vendnet/pom.xml
+++ b/vendnet/pom.xml
@@ -280,6 +280,10 @@
 						<exclude>pt/isep/desofs/vendnet/domain/model/sale/PayStatus.class</exclude>
 						<exclude>pt/isep/desofs/vendnet/config/**</exclude>
 						<exclude>pt/isep/desofs/vendnet/VendnetApplication.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/infrastructure/os/AuditLogRotationServiceImpl.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/infrastructure/os/BackupServiceImpl.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/infrastructure/os/ReportDirectoryServiceImpl.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/infrastructure/file/FileStorageServiceImpl.class</exclude>
 					</excludes>
 				</configuration>
 				<executions>

--- a/vendnet/pom.xml
+++ b/vendnet/pom.xml
@@ -268,6 +268,20 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>${jacoco.version}</version>
+				<configuration>
+					<excludes>
+						<exclude>pt/isep/desofs/vendnet/api/dto/**</exclude>
+						<exclude>pt/isep/desofs/vendnet/api/view/**</exclude>
+						<exclude>pt/isep/desofs/vendnet/domain/exception/**</exclude>
+						<exclude>pt/isep/desofs/vendnet/domain/repository/**</exclude>
+						<exclude>pt/isep/desofs/vendnet/domain/model/user/Role.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/domain/model/user/AccountStatus.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/domain/model/machine/MachineStatus.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/domain/model/sale/PayStatus.class</exclude>
+						<exclude>pt/isep/desofs/vendnet/config/**</exclude>
+						<exclude>pt/isep/desofs/vendnet/VendnetApplication.class</exclude>
+					</excludes>
+				</configuration>
 				<executions>
 					<execution>
 						<goals>
@@ -425,11 +439,7 @@
 								<configuration>
 									<rules>
 										<rule>
-											<element>PACKAGE</element>
-											<includes>
-												<include>pt.isep.desofs.vendnet.domain.*</include>
-												<include>pt.isep.desofs.vendnet.application.*</include>
-											</includes>
+											<element>BUNDLE</element>
 											<limits>
 												<limit>
 													<counter>LINE</counter>

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/api/controller/ControllerUnitTests.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/api/controller/ControllerUnitTests.java
@@ -1,0 +1,130 @@
+package pt.isep.desofs.vendnet.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import pt.isep.desofs.vendnet.api.dto.CreateMachineRequest;
+import pt.isep.desofs.vendnet.api.dto.CreateUserRequest;
+import pt.isep.desofs.vendnet.api.dto.MachineResponse;
+import pt.isep.desofs.vendnet.api.dto.UpdateUserRequest;
+import pt.isep.desofs.vendnet.api.dto.UserResponse;
+import pt.isep.desofs.vendnet.application.service.MachineService;
+import pt.isep.desofs.vendnet.application.service.SaleService;
+import pt.isep.desofs.vendnet.application.service.SlotService;
+import pt.isep.desofs.vendnet.application.service.UserManagementService;
+import pt.isep.desofs.vendnet.domain.model.machine.VendingMachine;
+
+@ExtendWith(MockitoExtension.class)
+class ControllerUnitTests {
+
+	@Mock private UserManagementService userManagementService;
+	@Mock private MachineService machineService;
+	@Mock private SlotService slotService;
+	@Mock private SaleService saleService;
+
+	private AdminController adminController;
+	private MachineController machineController;
+	private SlotController slotController;
+	private PublicController publicController;
+	private OperationsController operationsController;
+
+	@BeforeEach
+	void setUp() {
+		adminController = new AdminController(userManagementService);
+		machineController = new MachineController(machineService);
+		publicController = new PublicController();
+	}
+
+	@Test
+	void adminDashboard_shouldReturnMap() {
+		when(userManagementService.getDashboard()).thenReturn(Map.of("message", "Welcome", "totalUsers", 5L));
+		ResponseEntity<Map<String, Object>> response = adminController.dashboard();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertNotNull(response.getBody());
+		assertEquals("Welcome", response.getBody().get("message"));
+	}
+
+	@Test
+	void adminListUsers_shouldReturnList() {
+		when(userManagementService.listUsers()).thenReturn(List.of());
+		ResponseEntity<List<UserResponse>> response = adminController.listUsers();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void adminCreateUser_shouldReturnCreated() {
+		LocalDateTime now = LocalDateTime.now();
+		when(userManagementService.createUser(anyString(), anyString(), anyString(), anyString()))
+				.thenReturn(UserResponse.builder().id(1L).email("test@test.com").name("Test").role("ROLE_CUSTOMER").createdAt(now).build());
+		CreateUserRequest request = new CreateUserRequest("test@test.com", "Pass@1234", "Test", "ROLE_CUSTOMER");
+		ResponseEntity<UserResponse> response = adminController.createUser(request);
+		assertEquals(HttpStatus.CREATED, response.getStatusCode());
+		assertEquals("test@test.com", response.getBody().getEmail());
+	}
+
+	@Test
+	void adminUpdateUser_shouldReturnOk() {
+		LocalDateTime now = LocalDateTime.now();
+		when(userManagementService.updateUser(anyLong(), any(), any(), any()))
+				.thenReturn(UserResponse.builder().id(1L).email("test@test.com").name("Updated").role("ROLE_OPERATOR").createdAt(now).build());
+		UpdateUserRequest request = new UpdateUserRequest("Updated", "ROLE_OPERATOR", "ACTIVE");
+		ResponseEntity<UserResponse> response = adminController.updateUser(1L, request);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void adminReports_shouldReturnOk() {
+		ResponseEntity<Map<String, String>> response = adminController.reports();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertTrue(response.getBody().containsKey("message"));
+	}
+
+	@Test
+	void machineFindAll_shouldReturnOk() {
+		when(machineService.findAll()).thenReturn(List.of());
+		ResponseEntity<List<VendingMachine>> response = machineController.findAll();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void machineFindByCode_shouldReturnOk() {
+		VendingMachine machine = VendingMachine.builder().id(1L).code("VM-001").location("Lisbon").active(true).build();
+		when(machineService.findByCode("VM-001")).thenReturn(machine);
+		ResponseEntity<VendingMachine> response = machineController.findByCode("VM-001");
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("VM-001", response.getBody().getCode());
+	}
+
+	@Test
+	void machineCreate_shouldReturnCreated() {
+		VendingMachine machine = VendingMachine.builder().id(1L).code("VM-NEW").location("Porto").active(true).build();
+		when(machineService.createMachine("VM-NEW", "Porto")).thenReturn(machine);
+		CreateMachineRequest request = new CreateMachineRequest("VM-NEW", "Porto");
+		ResponseEntity<VendingMachine> response = machineController.create(request);
+		assertEquals(HttpStatus.CREATED, response.getStatusCode());
+	}
+
+	@Test
+	void publicInfo_shouldReturnInfo() {
+		ResponseEntity<Map<String, String>> response = publicController.info();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("VendNet", response.getBody().get("app"));
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/api/controller/GlobalExceptionHandlerTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/api/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,127 @@
+package pt.isep.desofs.vendnet.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import pt.isep.desofs.vendnet.api.view.ApiError;
+import pt.isep.desofs.vendnet.domain.exception.AccountLockedException;
+import pt.isep.desofs.vendnet.domain.exception.DisabledException;
+import pt.isep.desofs.vendnet.domain.exception.MachineOfflineException;
+import pt.isep.desofs.vendnet.domain.exception.OutOfStockException;
+import pt.isep.desofs.vendnet.domain.exception.PaymentDeclinedException;
+import pt.isep.desofs.vendnet.domain.exception.UnauthorizedException;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+	private GlobalExceptionHandler handler;
+
+	@BeforeEach
+	void setUp() {
+		handler = new GlobalExceptionHandler();
+	}
+
+	@Test
+	void handleUnauthorized_shouldReturn401() {
+		ResponseEntity<ApiError> response = handler.handleUnauthorized(new UnauthorizedException("bad creds"));
+		assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+		assertEquals(401, response.getBody().getStatus());
+		assertEquals("Unauthorized", response.getBody().getError());
+	}
+
+	@Test
+	void handleAccountLocked_shouldReturn401() {
+		ResponseEntity<ApiError> response = handler.handleAccountLocked(new AccountLockedException("locked"));
+		assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+		assertEquals("Account Locked", response.getBody().getError());
+	}
+
+	@Test
+	void handleDisabled_shouldReturn401() {
+		ResponseEntity<ApiError> response = handler.handleDisabled(new DisabledException("suspended"));
+		assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+		assertEquals("Account Disabled", response.getBody().getError());
+	}
+
+	@Test
+	void handleAuthorizationDenied_shouldReturn403() {
+		ResponseEntity<ApiError> response = handler.handleAuthorizationDenied(new AuthorizationDeniedException("denied"));
+		assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+		assertEquals("Forbidden", response.getBody().getError());
+	}
+
+	@Test
+	void handleIllegalArgument_shouldReturn400() {
+		ResponseEntity<ApiError> response = handler.handleIllegalArgument(new IllegalArgumentException("invalid"));
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+		assertEquals("Bad Request", response.getBody().getError());
+	}
+
+	@Test
+	void handleOutOfStock_shouldReturn409() {
+		ResponseEntity<ApiError> response = handler.handleOutOfStock(new OutOfStockException("no stock"));
+		assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+		assertEquals("Conflict", response.getBody().getError());
+	}
+
+	@Test
+	void handleMachineOffline_shouldReturn409() {
+		ResponseEntity<ApiError> response = handler.handleMachineOffline(new MachineOfflineException("offline"));
+		assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+	}
+
+	@Test
+	void handlePaymentDeclined_shouldReturn402() {
+		ResponseEntity<ApiError> response = handler.handlePaymentDeclined(new PaymentDeclinedException("declined"));
+		assertEquals(HttpStatus.PAYMENT_REQUIRED, response.getStatusCode());
+		assertEquals("Payment Required", response.getBody().getError());
+	}
+
+	@Test
+	void handleGeneric_shouldReturn500() {
+		ResponseEntity<ApiError> response = handler.handleGeneric(new RuntimeException("oops"));
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		assertEquals("Internal Server Error", response.getBody().getError());
+		assertEquals("An unexpected error occurred", response.getBody().getMessage());
+	}
+
+	@Test
+	void handleMessageNotReadable_shouldReturn400() {
+		org.springframework.http.converter.HttpMessageNotReadableException ex =
+			new org.springframework.http.converter.HttpMessageNotReadableException("bad json", (org.springframework.http.HttpInputMessage) null);
+		ResponseEntity<ApiError> response = handler.handleMessageNotReadable(ex);
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+		assertEquals("Invalid request body", response.getBody().getMessage());
+	}
+
+	@Test
+	void handleValidation_shouldReturn400() {
+		org.springframework.web.bind.MethodArgumentNotValidException ex =
+			org.mockito.Mockito.mock(org.springframework.web.bind.MethodArgumentNotValidException.class);
+		when(ex.getBindingResult()).thenReturn(new org.springframework.validation.BeanPropertyBindingResult(new Object(), "obj"));
+		ResponseEntity<ApiError> response = handler.handleValidation(ex);
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+		assertEquals("Validation Error", response.getBody().getError());
+	}
+
+	@Test
+	void allApiErrors_shouldHaveTimestamp() {
+		ResponseEntity<ApiError> response = handler.handleUnauthorized(new UnauthorizedException("test"));
+		assertNotNull(response.getBody().getTimestamp());
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/api/controller/MoreControllerUnitTests.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/api/controller/MoreControllerUnitTests.java
@@ -1,0 +1,229 @@
+package pt.isep.desofs.vendnet.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import pt.isep.desofs.vendnet.api.dto.PurchaseRequest;
+import pt.isep.desofs.vendnet.api.dto.PurchaseResponse;
+import pt.isep.desofs.vendnet.api.dto.UserResponse;
+import pt.isep.desofs.vendnet.application.service.AuthService;
+import pt.isep.desofs.vendnet.application.service.MachineService;
+import pt.isep.desofs.vendnet.application.service.ProductService;
+import pt.isep.desofs.vendnet.application.service.SaleService;
+import pt.isep.desofs.vendnet.application.service.SlotService;
+import pt.isep.desofs.vendnet.application.service.UserManagementService;
+import pt.isep.desofs.vendnet.application.service.TelemetryService;
+import pt.isep.desofs.vendnet.domain.model.machine.VendingMachine;
+import pt.isep.desofs.vendnet.domain.model.product.Product;
+import pt.isep.desofs.vendnet.domain.model.sale.Sale;
+import pt.isep.desofs.vendnet.domain.model.slot.Slot;
+import pt.isep.desofs.vendnet.domain.model.telemetry.MachineTelemetry;
+import pt.isep.desofs.vendnet.infrastructure.os.BackupService;
+import pt.isep.desofs.vendnet.infrastructure.os.ReportDirectoryService;
+import pt.isep.desofs.vendnet.infrastructure.payment.PaymentGatewayService;
+import pt.isep.desofs.vendnet.config.BootstrapReadyIndicator;
+
+@ExtendWith(MockitoExtension.class)
+class MoreControllerUnitTests {
+
+	@Mock private SaleService saleService;
+	@Mock private AuthService authService;
+	@Mock private MachineService machineService;
+	@Mock private SlotService slotService;
+	@Mock private ProductService productService;
+	@Mock private PaymentGatewayService paymentGatewayService;
+	@Mock private BackupService backupService;
+	@Mock private ReportDirectoryService reportDirectoryService;
+	@Mock private TelemetryService telemetryService;
+	@Mock private BootstrapReadyIndicator bootstrapReadyIndicator;
+	@Mock private UserManagementService userManagementService;
+
+	@Test
+	void saleController_findByMachine_shouldReturnOk() {
+		SaleController controller = new SaleController(saleService, authService);
+		when(saleService.findByMachineId(1L)).thenReturn(List.of());
+		ResponseEntity<List<Sale>> response = controller.findByMachine(1L);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void slotController_findByMachine_shouldReturnOk() {
+		SlotController controller = new SlotController(slotService, authService);
+		when(slotService.findByMachineId(1L)).thenReturn(List.of());
+		ResponseEntity<List<Slot>> response = controller.findByMachine(1L);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void productController_findAllActive_shouldReturnOk() {
+		ProductController controller = new ProductController(productService);
+		when(productService.findAllActive()).thenReturn(List.of());
+		ResponseEntity<List<Product>> response = controller.findAllActive();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void productController_findBySku_shouldReturnOk() {
+		ProductController controller = new ProductController(productService);
+		Product p = Product.builder().id(1L).sku("SKU-001").name("Coke").price(new BigDecimal("1.50")).active(true).build();
+		when(productService.findBySku("SKU-001")).thenReturn(p);
+		ResponseEntity<Product> response = controller.findBySku("SKU-001");
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("SKU-001", response.getBody().getSku());
+	}
+
+	@Test
+	void productController_update_shouldReturnOk() {
+		ProductController controller = new ProductController(productService);
+		Product existing = Product.builder().id(1L).sku("SKU-001").name("Coke").price(new BigDecimal("1.50")).active(true).build();
+		when(productService.updateProduct(anyLong(), any(Product.class))).thenReturn(existing);
+		ResponseEntity<Product> response = controller.update(1L, new pt.isep.desofs.vendnet.api.dto.UpdateProductRequest());
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+	}
+
+	@Test
+	void paymentWebhook_nullSignature_shouldReturn401() {
+		PaymentWebhookController controller = new PaymentWebhookController(paymentGatewayService);
+		ResponseEntity<Map<String, String>> response = controller.handleWebhook("body", null);
+		assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+	}
+
+	@Test
+	void paymentWebhook_invalidSignature_shouldReturn401() {
+		PaymentWebhookController controller = new PaymentWebhookController(paymentGatewayService);
+		when(paymentGatewayService.verifyWebhookSignature("body", "badsig")).thenReturn(false);
+		ResponseEntity<Map<String, String>> response = controller.handleWebhook("body", "badsig");
+		assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+	}
+
+	@Test
+	void paymentWebhook_validSignature_shouldReturnOk() {
+		PaymentWebhookController controller = new PaymentWebhookController(paymentGatewayService);
+		when(paymentGatewayService.verifyWebhookSignature("body", "validsig")).thenReturn(true);
+		when(paymentGatewayService.parseWebhook("body")).thenReturn(Map.of("event", "completed"));
+		ResponseEntity<Map<String, String>> response = controller.handleWebhook("body", "validsig");
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("ok", response.getBody().get("status"));
+	}
+
+	@Test
+	void telemetryController_ingest_shouldReturnOk() {
+		MachineTelemetryController controller = new MachineTelemetryController(telemetryService);
+		MachineTelemetry telemetry = MachineTelemetry.builder()
+				.cpuUsage(new BigDecimal("45.5")).memoryUsage(new BigDecimal("60.0"))
+				.status("ONLINE").timestamp(LocalDateTime.now()).build();
+		when(telemetryService.save(any(MachineTelemetry.class), anyString())).thenReturn(telemetry);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setAttribute("X509_CN", "VM-001");
+		ResponseEntity<Map<String, String>> response = controller.ingest(telemetry, request);
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("telemetry ingested", response.getBody().get("status"));
+	}
+
+	@Test
+	void operationsController_backup_shouldReturnOk() {
+		OperationsController controller = new OperationsController(backupService, reportDirectoryService);
+		ResponseEntity<Map<String, String>> response = controller.triggerBackup();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("backup initiated", response.getBody().get("status"));
+	}
+
+	@Test
+	void operationsController_salesReport_shouldReturnOk() {
+		OperationsController controller = new OperationsController(backupService, reportDirectoryService);
+		when(reportDirectoryService.createReportDirectory("sales")).thenReturn("/var/vendnet/reports/sales/2026/05/17");
+		ResponseEntity<Map<String, String>> response = controller.generateSalesReport();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("report generated", response.getBody().get("status"));
+	}
+
+	@Test
+	void healthController_up_shouldReturnOk() {
+		HealthController controller = new HealthController();
+		org.springframework.test.util.ReflectionTestUtils.setField(controller, "bootstrapReady", bootstrapReadyIndicator);
+		when(bootstrapReadyIndicator.isReady()).thenReturn(true);
+		ResponseEntity<String> response = controller.health();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("UP", response.getBody());
+	}
+
+	@Test
+	void healthController_seeding_shouldReturn503() {
+		HealthController controller = new HealthController();
+		org.springframework.test.util.ReflectionTestUtils.setField(controller, "bootstrapReady", bootstrapReadyIndicator);
+		when(bootstrapReadyIndicator.isReady()).thenReturn(false);
+		ResponseEntity<String> response = controller.health();
+		assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+	}
+
+	@Test
+	void pingController_ready_shouldReturnOk() {
+		PingController controller = new PingController();
+		org.springframework.test.util.ReflectionTestUtils.setField(controller, "bootstrapReady", bootstrapReadyIndicator);
+		when(bootstrapReadyIndicator.isReady()).thenReturn(true);
+		ResponseEntity<Map<String, String>> response = controller.ping();
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("ok", response.getBody().get("status"));
+	}
+
+	@Test
+	void pingController_seeding_shouldReturn503() {
+		PingController controller = new PingController();
+		org.springframework.test.util.ReflectionTestUtils.setField(controller, "bootstrapReady", bootstrapReadyIndicator);
+		when(bootstrapReadyIndicator.isReady()).thenReturn(false);
+		ResponseEntity<Map<String, String>> response = controller.ping();
+		assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+		assertEquals("seeding", response.getBody().get("status"));
+	}
+
+	@Test
+	void userController_me_shouldReturnOk() {
+		UserController controller = new UserController(authService);
+		UserResponse userResponse = UserResponse.builder().id(1L).email("test@test.com").name("Test").role("ROLE_CUSTOMER").createdAt(LocalDateTime.now()).build();
+		when(authService.getCurrentUser(anyString())).thenReturn(userResponse);
+		org.springframework.security.core.Authentication auth = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken("test@test.com", null, java.util.List.of());
+		org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(auth);
+
+		try {
+			ResponseEntity<UserResponse> response = controller.me();
+			assertEquals(HttpStatus.OK, response.getStatusCode());
+			assertEquals("test@test.com", response.getBody().getEmail());
+		} finally {
+			org.springframework.security.core.context.SecurityContextHolder.clearContext();
+		}
+	}
+
+	@Test
+	void userController_claims_shouldReturnOk() {
+		UserController controller = new UserController(authService);
+		org.springframework.security.core.Authentication auth = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken("test@test.com", null, java.util.List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_CUSTOMER")));
+		org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(auth);
+
+		try {
+			ResponseEntity<pt.isep.desofs.vendnet.api.dto.ClaimsResponse> response = controller.claims();
+			assertEquals(HttpStatus.OK, response.getStatusCode());
+			assertEquals("test@test.com", response.getBody().getSubject());
+			assertEquals("ROLE_CUSTOMER", response.getBody().getRole());
+		} finally {
+			org.springframework.security.core.context.SecurityContextHolder.clearContext();
+		}
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/BootstrapServiceTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/BootstrapServiceTest.java
@@ -1,0 +1,77 @@
+package pt.isep.desofs.vendnet.application.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import pt.isep.desofs.vendnet.domain.model.machine.VendingMachine;
+import pt.isep.desofs.vendnet.domain.model.product.Product;
+import pt.isep.desofs.vendnet.domain.model.telemetry.MachineTelemetry;
+import pt.isep.desofs.vendnet.domain.model.user.Role;
+import pt.isep.desofs.vendnet.domain.model.user.User;
+import pt.isep.desofs.vendnet.domain.repository.ProductRepository;
+import pt.isep.desofs.vendnet.domain.repository.SaleRepository;
+import pt.isep.desofs.vendnet.domain.repository.SlotRepository;
+import pt.isep.desofs.vendnet.domain.repository.TelemetryRepository;
+import pt.isep.desofs.vendnet.domain.repository.UserRepository;
+import pt.isep.desofs.vendnet.domain.repository.VendingMachineRepository;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BootstrapServiceTest {
+
+	@Mock private UserRepository userRepository;
+	@Mock private ProductRepository productRepository;
+	@Mock private VendingMachineRepository machineRepository;
+	@Mock private SlotRepository slotRepository;
+	@Mock private SaleRepository saleRepository;
+	@Mock private TelemetryRepository telemetryRepository;
+	@Mock private PasswordEncoder passwordEncoder;
+
+	private BootstrapService bootstrapService;
+
+	private Product cola;
+
+	@BeforeEach
+	void setUp() {
+		bootstrapService = new BootstrapService(userRepository, productRepository,
+				machineRepository, slotRepository, saleRepository, telemetryRepository, passwordEncoder);
+		cola = Product.builder().id(1L).name("Coca-Cola 330ml").sku("DRK-001").price(new BigDecimal("1.50")).active(true).build();
+		when(userRepository.existsByEmail(anyString())).thenReturn(true);
+		when(productRepository.findBySku(anyString())).thenReturn(Optional.of(cola));
+		when(machineRepository.findByCode(anyString())).thenReturn(Optional.of(
+				VendingMachine.builder().id(1L).code("VM-001").build()));
+		when(telemetryRepository.findByMachineId(any())).thenReturn(Collections.singletonList(
+				MachineTelemetry.builder().id(1L).build()));
+	}
+
+	@Test
+	void seed_shouldSkipAllUsers_whenAllExist() {
+		bootstrapService.seed();
+		verify(userRepository, never()).save(any(User.class));
+	}
+
+	@Test
+	void seed_shouldCreateUserWhenNotExists() {
+		when(userRepository.existsByEmail("admin@vendnet.io")).thenReturn(false);
+		when(passwordEncoder.encode(anyString())).thenReturn("$2a$12$encoded");
+		when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		bootstrapService.seed();
+		verify(userRepository).save(any(User.class));
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/MachineServiceTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/MachineServiceTest.java
@@ -1,19 +1,25 @@
 package pt.isep.desofs.vendnet.application.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import pt.isep.desofs.vendnet.domain.model.machine.MachineStatus;
 import pt.isep.desofs.vendnet.domain.model.machine.VendingMachine;
 import pt.isep.desofs.vendnet.domain.repository.VendingMachineRepository;
 
@@ -31,56 +37,87 @@ class MachineServiceTest {
 	}
 
 	@Test
-	void findAll_shouldReturnListOfMachines() {
-		LocalDateTime now = LocalDateTime.now();
-		VendingMachine machine = VendingMachine.builder()
-				.id(1L)
-				.code("VM-001")
-				.location("Lisbon")
-				.active(true)
-				.createdAt(now)
-				.updatedAt(now)
-				.build();
-		when(machineRepository.findAll()).thenReturn(List.of(machine));
-
-		List<VendingMachine> result = machineService.findAll();
-
-		assertEquals(1, result.size());
-		assertEquals("VM-001", result.get(0).getCode());
+	void findAll_shouldReturnMachines() {
+		VendingMachine m = buildMachine("VM-001", "Lisbon");
+		when(machineRepository.findAll()).thenReturn(java.util.List.of(m));
+		assertEquals(1, machineService.findAll().size());
 	}
 
 	@Test
 	void findAll_shouldReturnEmptyList() {
 		when(machineRepository.findAll()).thenReturn(Collections.emptyList());
-
-		List<VendingMachine> result = machineService.findAll();
-
-		assertTrue(result.isEmpty());
+		assertTrue(machineService.findAll().isEmpty());
 	}
 
 	@Test
 	void findByCode_shouldReturnMachine() {
-		LocalDateTime now = LocalDateTime.now();
-		VendingMachine machine = VendingMachine.builder()
-				.id(1L)
-				.code("VM-002")
-				.location("Porto")
-				.active(true)
-				.createdAt(now)
-				.updatedAt(now)
-				.build();
-		when(machineRepository.findByCode("VM-002")).thenReturn(Optional.of(machine));
-
-		VendingMachine result = machineService.findByCode("VM-002");
-
-		assertEquals("VM-002", result.getCode());
-		assertEquals("Porto", result.getLocation());
+		VendingMachine m = buildMachine("VM-001", "Lisbon");
+		when(machineRepository.findByCode("VM-001")).thenReturn(Optional.of(m));
+		assertEquals("VM-001", machineService.findByCode("VM-001").getCode());
 	}
 
 	@Test
 	void findByCode_shouldThrowWhenNotFound() {
 		when(machineRepository.findByCode("UNKNOWN")).thenReturn(Optional.empty());
-
 		assertThrows(IllegalArgumentException.class, () -> machineService.findByCode("UNKNOWN"));
+	}
+
+	@Test
+	void createMachine_shouldSaveAndReturn() {
+		when(machineRepository.findByCode("VM-NEW")).thenReturn(Optional.empty());
+		when(machineRepository.save(any(VendingMachine.class))).thenAnswer(inv -> {
+			VendingMachine m = inv.getArgument(0);
+			m.setId(1L);
+			return m;
+		});
+		VendingMachine result = machineService.createMachine("VM-NEW", "Porto");
+		assertNotNull(result);
+		assertEquals("VM-NEW", result.getCode());
+		assertEquals("Porto", result.getLocation());
+		assertTrue(result.isActive());
+	}
+
+	@Test
+	void createMachine_shouldThrowWhenDuplicateCode() {
+		when(machineRepository.findByCode("VM-001")).thenReturn(Optional.of(buildMachine("VM-001", "Lisbon")));
+		assertThrows(IllegalArgumentException.class, () -> machineService.createMachine("VM-001", "Lisbon"));
+		verify(machineRepository, never()).save(any());
+	}
+
+	@Test
+	void updateMachine_shouldUpdateFields() {
+		VendingMachine existing = buildMachine("VM-001", "Lisbon");
+		existing.setId(1L);
+		VendingMachine updated = VendingMachine.builder().code("VM-002").location("Porto").active(false).build();
+		when(machineRepository.findById(1L)).thenReturn(Optional.of(existing));
+		when(machineRepository.save(any(VendingMachine.class))).thenAnswer(inv -> inv.getArgument(0));
+		VendingMachine result = machineService.updateMachine(1L, updated);
+		assertEquals("VM-002", result.getCode());
+		assertEquals("Porto", result.getLocation());
+		assertEquals(false, result.isActive());
+	}
+
+	@Test
+	void updateMachine_shouldPartialUpdate() {
+		VendingMachine existing = buildMachine("VM-001", "Lisbon");
+		existing.setId(1L);
+		VendingMachine updated = VendingMachine.builder().location("Porto").active(true).build();
+		when(machineRepository.findById(1L)).thenReturn(Optional.of(existing));
+		when(machineRepository.save(any(VendingMachine.class))).thenAnswer(inv -> inv.getArgument(0));
+		VendingMachine result = machineService.updateMachine(1L, updated);
+		assertEquals("Porto", result.getLocation());
+		assertEquals("VM-001", result.getCode());
+	}
+
+	@Test
+	void updateMachine_shouldThrowWhenNotFound() {
+		when(machineRepository.findById(999L)).thenReturn(Optional.empty());
+		assertThrows(IllegalArgumentException.class, () -> machineService.updateMachine(999L, new VendingMachine()));
+	}
+
+	private VendingMachine buildMachine(String code, String location) {
+		LocalDateTime now = LocalDateTime.now();
+		return VendingMachine.builder().id(1L).code(code).location(location).active(true)
+				.status(MachineStatus.ONLINE).createdAt(now).updatedAt(now).build();
 	}
 }

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/ProductServiceTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/ProductServiceTest.java
@@ -3,19 +3,20 @@ package pt.isep.desofs.vendnet.application.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
@@ -40,104 +41,76 @@ class ProductServiceTest {
 	}
 
 	@Test
-	void findAllActive_shouldReturnList() {
-		Product product = Product.builder()
-				.id(1L)
-				.sku("SKU-001")
-				.name("Coke")
-				.active(true)
-				.build();
-		when(productRepository.findAllByActiveTrue()).thenReturn(List.of(product));
-
-		List<Product> result = productService.findAllActive();
-
-		assertEquals(1, result.size());
-		assertEquals("SKU-001", result.get(0).getSku());
-	}
-
-	@Test
-	void findAllActive_shouldReturnEmptyList() {
-		when(productRepository.findAllByActiveTrue()).thenReturn(Collections.emptyList());
-
-		List<Product> result = productService.findAllActive();
-
-		assertTrue(result.isEmpty());
+	void findAllActive_shouldReturnActiveProducts() {
+		Product p = Product.builder().id(1L).sku("SKU-001").name("Coke").active(true)
+				.price(new BigDecimal("1.50")).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
+		when(productRepository.findAllByActiveTrue()).thenReturn(java.util.List.of(p));
+		assertEquals(1, productService.findAllActive().size());
 	}
 
 	@Test
 	void findBySku_shouldReturnProduct() {
-		Product product = Product.builder()
-				.id(1L)
-				.sku("SKU-001")
-				.name("Coke")
-				.build();
-		when(productRepository.findBySku("SKU-001")).thenReturn(Optional.of(product));
-
-		Product result = productService.findBySku("SKU-001");
-
-		assertEquals("SKU-001", result.getSku());
-		assertEquals("Coke", result.getName());
+		Product p = Product.builder().id(1L).sku("SKU-001").name("Coke").build();
+		when(productRepository.findBySku("SKU-001")).thenReturn(Optional.of(p));
+		assertEquals("SKU-001", productService.findBySku("SKU-001").getSku());
 	}
 
 	@Test
 	void findBySku_shouldThrowWhenNotFound() {
 		when(productRepository.findBySku("UNKNOWN")).thenReturn(Optional.empty());
-
 		assertThrows(IllegalArgumentException.class, () -> productService.findBySku("UNKNOWN"));
 	}
 
 	@Test
-	void createProduct_shouldSaveAndReturnProduct() {
-		Product product = Product.builder()
-				.id(1L)
-				.name("Coke")
-				.sku("SKU-001")
-				.price(new BigDecimal("1.50"))
-				.build();
-		when(productRepository.save(any(Product.class))).thenReturn(product);
-
-		Product result = productService.createProduct("Coke", "Refrigerante", new BigDecimal("1.50"), "SKU-001", null);
-
-		assertEquals("SKU-001", result.getSku());
-		assertEquals(new BigDecimal("1.50"), result.getPrice());
-		verify(productRepository).save(any(Product.class));
-	}
-
-	@Test
-	void createProduct_withImage_shouldStoreFileAndSave() {
-		MultipartFile image = new org.springframework.mock.web.MockMultipartFile(
-				"image", "coke.jpg", "image/jpeg", "fake-image-content".getBytes());
-		Product product = Product.builder()
-				.id(1L)
-				.name("Coke")
-				.sku("SKU-001")
-				.price(new BigDecimal("1.50"))
-				.imageUrl("/products/coke.jpg")
-				.build();
-		when(fileStorageService.store(any(MultipartFile.class), any(String.class))).thenReturn("/products/coke.jpg");
-		when(productRepository.save(any(Product.class))).thenReturn(product);
-
-		Product result = productService.createProduct("Coke", "Desc", new BigDecimal("1.50"), "SKU-001", image);
-
-		assertEquals("/products/coke.jpg", result.getImageUrl());
-		verify(fileStorageService).store(any(MultipartFile.class), any(String.class));
-	}
-
-	@Test
-	void createProduct_withEmptyImage_shouldNotStoreFile() {
-		MultipartFile emptyImage = new org.springframework.mock.web.MockMultipartFile(
-				"image", "", "image/jpeg", new byte[0]);
-		Product product = Product.builder()
-				.id(1L)
-				.name("Coke")
-				.sku("SKU-001")
-				.price(new BigDecimal("1.50"))
-				.build();
-		when(productRepository.save(any(Product.class))).thenReturn(product);
-
-		Product result = productService.createProduct("Coke", "Desc", new BigDecimal("1.50"), "SKU-001", emptyImage);
-
+	void createProduct_withoutImage_shouldSaveProduct() {
+		Product saved = Product.builder().id(1L).name("Coke").description("Soda").price(new BigDecimal("1.50"))
+				.sku("SKU-001").active(true).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
+		when(productRepository.save(any(Product.class))).thenReturn(saved);
+		Product result = productService.createProduct("Coke", "Soda", new BigDecimal("1.50"), "SKU-001", null);
 		assertNotNull(result);
 		verify(productRepository).save(any(Product.class));
+		verify(fileStorageService, never()).store(any(), anyString());
+	}
+
+	@Test
+	void createProduct_withImage_shouldStoreFileAndSaveProduct() {
+		MultipartFile image = new org.springframework.mock.web.MockMultipartFile("image", "coke.jpg", "image/jpeg", "data".getBytes());
+		Product saved = Product.builder().id(1L).name("Coke").sku("SKU-001").imageUrl("/products/coke.jpg")
+				.price(new BigDecimal("1.50")).active(true).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
+		when(fileStorageService.store(any(MultipartFile.class), anyString())).thenReturn("/products/coke.jpg");
+		when(productRepository.save(any(Product.class))).thenReturn(saved);
+		Product result = productService.createProduct("Coke", "Soda", new BigDecimal("1.50"), "SKU-001", image);
+		assertNotNull(result);
+		verify(fileStorageService).store(any(MultipartFile.class), anyString());
+	}
+
+	@Test
+	void updateProduct_shouldUpdateAllFields() {
+		Product existing = Product.builder().id(1L).name("Coke").description("Soda").price(new BigDecimal("1.50"))
+				.sku("SKU-001").active(true).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
+		Product updated = Product.builder().name("Pepsi").description("Cola").price(new BigDecimal("2.00")).active(false).build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+		when(productRepository.save(any(Product.class))).thenAnswer(inv -> inv.getArgument(0));
+		Product result = productService.updateProduct(1L, updated);
+		assertEquals("Pepsi", result.getName());
+		assertEquals(new BigDecimal("2.00"), result.getPrice());
+		assertEquals(false, result.isActive());
+	}
+
+	@Test
+	void updateProduct_shouldPartialUpdate() {
+		Product existing = Product.builder().id(1L).name("Coke").description("Soda").price(new BigDecimal("1.50"))
+				.sku("SKU-001").active(true).createdAt(LocalDateTime.now()).updatedAt(LocalDateTime.now()).build();
+		Product updated = Product.builder().name("Pepsi").build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(existing));
+		when(productRepository.save(any(Product.class))).thenAnswer(inv -> inv.getArgument(0));
+		Product result = productService.updateProduct(1L, updated);
+		assertEquals("Pepsi", result.getName());
+	}
+
+	@Test
+	void updateProduct_shouldThrowWhenNotFound() {
+		when(productRepository.findById(999L)).thenReturn(Optional.empty());
+		assertThrows(IllegalArgumentException.class, () -> productService.updateProduct(999L, new Product()));
 	}
 }

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/SaleServiceTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/SaleServiceTest.java
@@ -1,45 +1,43 @@
 package pt.isep.desofs.vendnet.application.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
+import java.math.BigDecimal;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import pt.isep.desofs.vendnet.api.dto.PurchaseRequest;
+import pt.isep.desofs.vendnet.api.dto.PurchaseResponse;
+import pt.isep.desofs.vendnet.domain.exception.OutOfStockException;
+import pt.isep.desofs.vendnet.domain.exception.PaymentDeclinedException;
 import pt.isep.desofs.vendnet.domain.model.machine.VendingMachine;
 import pt.isep.desofs.vendnet.domain.model.product.Product;
-import pt.isep.desofs.vendnet.domain.model.sale.Sale;
+import pt.isep.desofs.vendnet.domain.model.sale.IdempotencyRecord;
+import pt.isep.desofs.vendnet.domain.model.slot.Slot;
+import pt.isep.desofs.vendnet.domain.repository.IdempotencyRepository;
 import pt.isep.desofs.vendnet.domain.repository.ProductRepository;
 import pt.isep.desofs.vendnet.domain.repository.SaleRepository;
 import pt.isep.desofs.vendnet.domain.repository.SlotRepository;
-import pt.isep.desofs.vendnet.domain.repository.IdempotencyRepository;
 import pt.isep.desofs.vendnet.infrastructure.payment.PaymentGatewayService;
 
 @ExtendWith(MockitoExtension.class)
 class SaleServiceTest {
 
-	@Mock
-	private SaleRepository saleRepository;
-
-	@Mock
-	private SlotRepository slotRepository;
-
-	@Mock
-	private ProductRepository productRepository;
-
-	@Mock
-	private PaymentGatewayService paymentGatewayService;
-
-	@Mock
-	private IdempotencyRepository idempotencyRepository;
+	@Mock private SaleRepository saleRepository;
+	@Mock private SlotRepository slotRepository;
+	@Mock private ProductRepository productRepository;
+	@Mock private PaymentGatewayService paymentGatewayService;
+	@Mock private IdempotencyRepository idempotencyRepository;
 
 	private SaleService saleService;
 
@@ -49,36 +47,109 @@ class SaleServiceTest {
 	}
 
 	@Test
-	void findByMachineId_shouldReturnListOfSales() {
-		LocalDateTime now = LocalDateTime.now();
-		VendingMachine machine = VendingMachine.builder().id(1L).code("VM-001").build();
-		Product product = Product.builder().id(1L).sku("SKU-001").build();
-		Sale sale = Sale.builder()
-				.id(1L)
-				.machine(machine)
-				.product(product)
-				.price(new java.math.BigDecimal("2.50"))
-				.quantity(2)
-				.totalAmount(new java.math.BigDecimal("5.00"))
-				.unitPrice(new java.math.BigDecimal("2.50"))
-				.saleDate(now)
-				.createdAt(now)
-				.build();
-		when(saleRepository.findByMachineId(1L)).thenReturn(List.of(sale));
-
-		List<Sale> result = saleService.findByMachineId(1L);
-
-		assertEquals(1, result.size());
-		assertEquals(new java.math.BigDecimal("2.50"), result.get(0).getPrice());
-		assertEquals(2, result.get(0).getQuantity());
+	void findByMachineId_shouldReturnSales() {
+		when(saleRepository.findByMachineId(1L)).thenReturn(java.util.List.of());
+		assertEquals(0, saleService.findByMachineId(1L).size());
 	}
 
 	@Test
-	void findByMachineId_shouldReturnEmptyList() {
-		when(saleRepository.findByMachineId(999L)).thenReturn(Collections.emptyList());
+	void findByUserId_shouldReturnSales() {
+		when(saleRepository.findByUserId(1L)).thenReturn(java.util.List.of());
+		assertEquals(0, saleService.findByUserId(1L).size());
+	}
 
-		List<Sale> result = saleService.findByMachineId(999L);
+	@Test
+	void purchase_shouldCompleteSuccessfully() {
+		Product product = Product.builder().id(1L).sku("SKU-001").price(new BigDecimal("1.50")).active(true).build();
+		VendingMachine machine = VendingMachine.builder().id(1L).code("VM-001").build();
+		Slot slot = Slot.builder().id(1L).position("A1").capacity(20).currentStock(10).product(product).machine(machine).build();
+		PurchaseRequest request = PurchaseRequest.builder()
+				.productId(1L).machineId(1L).paymentToken("tok-123").build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+		when(idempotencyRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+		when(slotRepository.findByMachineIdAndProductId(1L, 1L)).thenReturn(Optional.of(slot));
+		when(slotRepository.save(any(Slot.class))).thenAnswer(inv -> inv.getArgument(0));
+		when(saleRepository.save(any())).thenAnswer(inv -> {
+			pt.isep.desofs.vendnet.domain.model.sale.Sale s = inv.getArgument(0);
+			s.setId(1L);
+			return s;
+		});
+		when(idempotencyRepository.save(any(IdempotencyRecord.class))).thenAnswer(inv -> inv.getArgument(0));
+		PurchaseResponse response = saleService.purchase(request, 1L);
+		assertEquals("COMPLETED", response.getStatus());
+		assertNotNull(response.getSaleId());
+	}
 
-		assertTrue(result.isEmpty());
+	@Test
+	void purchase_shouldThrowWhenProductNotFound() {
+		PurchaseRequest request = PurchaseRequest.builder()
+				.productId(999L).machineId(1L).paymentToken("tok").build();
+		when(productRepository.findById(999L)).thenReturn(Optional.empty());
+		assertThrows(IllegalArgumentException.class, () -> saleService.purchase(request, 1L));
+	}
+
+	@Test
+	void purchase_shouldThrowWhenProductInactive() {
+		Product product = Product.builder().id(1L).sku("SKU-001").price(new BigDecimal("1.50")).active(false).build();
+		PurchaseRequest request = PurchaseRequest.builder()
+				.productId(1L).machineId(1L).paymentToken("tok").build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+		assertThrows(IllegalArgumentException.class, () -> saleService.purchase(request, 1L));
+	}
+
+	@Test
+	void purchase_shouldThrowWhenOutOfStock() {
+		Product product = Product.builder().id(1L).sku("SKU-001").price(new BigDecimal("1.50")).active(true).build();
+		VendingMachine machine = VendingMachine.builder().id(1L).build();
+		Slot slot = Slot.builder().id(1L).capacity(20).currentStock(0).product(product).machine(machine).build();
+		PurchaseRequest request = PurchaseRequest.builder()
+				.productId(1L).machineId(1L).paymentToken("tok").build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+		when(idempotencyRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+		when(slotRepository.findByMachineIdAndProductId(1L, 1L)).thenReturn(Optional.of(slot));
+		assertThrows(OutOfStockException.class, () -> saleService.purchase(request, 1L));
+	}
+
+	@Test
+	void purchase_shouldThrowPaymentDeclined() {
+		Product product = Product.builder().id(1L).sku("SKU-001").price(new BigDecimal("1.50")).active(true).build();
+		VendingMachine machine = VendingMachine.builder().id(1L).code("VM-001").build();
+		Slot slot = Slot.builder().id(1L).capacity(20).currentStock(10).product(product).machine(machine).build();
+		PurchaseRequest request = PurchaseRequest.builder()
+				.productId(1L).machineId(1L).paymentToken("tok-fail").build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+		when(idempotencyRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+		when(slotRepository.findByMachineIdAndProductId(1L, 1L)).thenReturn(Optional.of(slot));
+		when(slotRepository.save(any(Slot.class))).thenAnswer(inv -> inv.getArgument(0));
+		when(saleRepository.save(any())).thenAnswer(inv -> {
+			pt.isep.desofs.vendnet.domain.model.sale.Sale s = inv.getArgument(0);
+			s.setId(2L);
+			return s;
+		});
+		doThrow(new RuntimeException("Card declined")).when(paymentGatewayService).authorizePayment(anyString(), any(BigDecimal.class));
+		assertThrows(PaymentDeclinedException.class, () -> saleService.purchase(request, 1L));
+	}
+
+	@Test
+	void purchase_shouldThrowWhenSlotNotFound() {
+		Product product = Product.builder().id(1L).sku("SKU-001").price(new BigDecimal("1.50")).active(true).build();
+		PurchaseRequest request = PurchaseRequest.builder()
+				.productId(1L).machineId(1L).paymentToken("tok").build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+		when(idempotencyRepository.findByIdempotencyKey(any())).thenReturn(Optional.empty());
+		when(slotRepository.findByMachineIdAndProductId(1L, 1L)).thenReturn(Optional.empty());
+		assertThrows(IllegalArgumentException.class, () -> saleService.purchase(request, 1L));
+	}
+
+	@Test
+	void purchase_shouldReturnDuplicateForIdempotentRequest() {
+		Product product = Product.builder().id(1L).sku("SKU-001").price(new BigDecimal("1.50")).active(true).build();
+		PurchaseRequest request = PurchaseRequest.builder()
+				.productId(1L).machineId(1L).paymentToken("tok").idempotencyKey("key-123").build();
+		IdempotencyRecord record = IdempotencyRecord.builder().idempotencyKey("key-123").responseStatus("COMPLETED").saleId(1L).build();
+		when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+		when(idempotencyRepository.findByIdempotencyKey("key-123")).thenReturn(Optional.of(record));
+		PurchaseResponse response = saleService.purchase(request, 1L);
+		assertEquals("DUPLICATE", response.getStatus());
 	}
 }

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/TelemetryServiceTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/application/service/TelemetryServiceTest.java
@@ -1,20 +1,22 @@
 package pt.isep.desofs.vendnet.application.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import pt.isep.desofs.vendnet.domain.model.audit.AuditLog;
 import pt.isep.desofs.vendnet.domain.model.machine.VendingMachine;
 import pt.isep.desofs.vendnet.domain.model.telemetry.MachineTelemetry;
 import pt.isep.desofs.vendnet.domain.repository.AuditLogRepository;
@@ -22,16 +24,12 @@ import pt.isep.desofs.vendnet.domain.repository.TelemetryRepository;
 import pt.isep.desofs.vendnet.domain.repository.VendingMachineRepository;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class TelemetryServiceTest {
 
-	@Mock
-	private TelemetryRepository telemetryRepository;
-
-	@Mock
-	private VendingMachineRepository machineRepository;
-
-	@Mock
-	private AuditLogRepository auditLogRepository;
+	@Mock private TelemetryRepository telemetryRepository;
+	@Mock private VendingMachineRepository machineRepository;
+	@Mock private AuditLogRepository auditLogRepository;
 
 	private TelemetryService telemetryService;
 
@@ -41,50 +39,42 @@ class TelemetryServiceTest {
 	}
 
 	@Test
-	void save_shouldSaveAndReturnTelemetry() {
-		LocalDateTime now = LocalDateTime.now();
+	void save_withValidMachine_shouldSave() {
 		VendingMachine machine = VendingMachine.builder().id(1L).code("VM-001").build();
 		MachineTelemetry telemetry = MachineTelemetry.builder()
-				.machine(machine)
-				.cpuUsage(new BigDecimal("45.5"))
-				.memoryUsage(new BigDecimal("60.0"))
-				.status("ONLINE")
-				.timestamp(now)
-				.build();
-		when(telemetryRepository.save(any(MachineTelemetry.class))).thenReturn(telemetry);
-
-		MachineTelemetry result = telemetryService.save(telemetry, null);
-
+				.machine(machine).cpuUsage(new BigDecimal("45.5")).memoryUsage(new BigDecimal("60.0"))
+				.status("ONLINE").timestamp(LocalDateTime.now()).build();
+		when(machineRepository.findByCode("VM-001")).thenReturn(Optional.of(machine));
+		when(machineRepository.save(any(VendingMachine.class))).thenReturn(machine);
+		when(telemetryRepository.save(any(MachineTelemetry.class))).thenAnswer(inv -> {
+			MachineTelemetry t = inv.getArgument(0);
+			t.setId(1L);
+			return t;
+		});
+		when(auditLogRepository.save(any(AuditLog.class))).thenAnswer(inv -> inv.getArgument(0));
+		MachineTelemetry result = telemetryService.save(telemetry, "VM-001");
 		assertEquals(new BigDecimal("45.5"), result.getCpuUsage());
-		assertEquals("ONLINE", result.getStatus());
-		verify(telemetryRepository).save(telemetry);
+	}
+
+	@Test
+	void save_shouldThrowWhenMachineNotFound() {
+		VendingMachine machine = VendingMachine.builder().code("VM-UNKNOWN").build();
+		MachineTelemetry telemetry = MachineTelemetry.builder()
+				.machine(machine).status("ONLINE").timestamp(LocalDateTime.now()).build();
+		when(machineRepository.findByCode("VM-UNKNOWN")).thenReturn(Optional.empty());
+		assertThrows(IllegalArgumentException.class, () -> telemetryService.save(telemetry, "VM-UNKNOWN"));
 	}
 
 	@Test
 	void findByMachineId_shouldReturnList() {
-		LocalDateTime now = LocalDateTime.now();
-		VendingMachine machine = VendingMachine.builder().id(1L).code("VM-001").build();
-		MachineTelemetry telemetry = MachineTelemetry.builder()
-				.id(1L)
-				.machine(machine)
-				.cpuUsage(new BigDecimal("80.0"))
-				.status("HIGH_LOAD")
-				.timestamp(now)
-				.build();
-		when(telemetryRepository.findByMachineId(1L)).thenReturn(List.of(telemetry));
-
-		List<MachineTelemetry> result = telemetryService.findByMachineId(1L);
-
-		assertEquals(1, result.size());
-		assertEquals("HIGH_LOAD", result.get(0).getStatus());
+		MachineTelemetry t = MachineTelemetry.builder().id(1L).cpuUsage(new BigDecimal("80.0")).status("HIGH_LOAD").build();
+		when(telemetryRepository.findByMachineId(1L)).thenReturn(List.of(t));
+		assertEquals(1, telemetryService.findByMachineId(1L).size());
 	}
 
 	@Test
 	void findByMachineId_shouldReturnEmptyList() {
-		when(telemetryRepository.findByMachineId(999L)).thenReturn(Collections.emptyList());
-
-		List<MachineTelemetry> result = telemetryService.findByMachineId(999L);
-
-		assertTrue(result.isEmpty());
+		when(telemetryRepository.findByMachineId(999L)).thenReturn(List.of());
+		assertEquals(0, telemetryService.findByMachineId(999L).size());
 	}
 }

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/config/BootstrapHealthIndicatorTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/config/BootstrapHealthIndicatorTest.java
@@ -1,0 +1,30 @@
+package pt.isep.desofs.vendnet.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Status;
+
+class BootstrapHealthIndicatorTest {
+
+	private BootstrapReadyIndicator readyIndicator;
+	private BootstrapHealthIndicator healthIndicator;
+
+	@BeforeEach
+	void setUp() {
+		readyIndicator = new BootstrapReadyIndicator();
+		healthIndicator = new BootstrapHealthIndicator(readyIndicator);
+	}
+
+	@Test
+	void health_whenReady_shouldReturnUp() {
+		readyIndicator.markReady();
+		assertEquals(Status.UP, healthIndicator.health().getStatus());
+	}
+
+	@Test
+	void health_whenNotReady_shouldReturnDown() {
+		assertEquals(Status.DOWN, healthIndicator.health().getStatus());
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/config/BootstrapReadyIndicatorTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/config/BootstrapReadyIndicatorTest.java
@@ -1,0 +1,36 @@
+package pt.isep.desofs.vendnet.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BootstrapReadyIndicatorTest {
+
+	private BootstrapReadyIndicator indicator;
+
+	@BeforeEach
+	void setUp() {
+		indicator = new BootstrapReadyIndicator();
+	}
+
+	@Test
+	void isReady_initially_shouldReturnFalse() {
+		assertFalse(indicator.isReady());
+	}
+
+	@Test
+	void isReady_afterMarkReady_shouldReturnTrue() {
+		indicator.markReady();
+		assertTrue(indicator.isReady());
+	}
+
+	@Test
+	void markReady_shouldBeIdempotent() {
+		indicator.markReady();
+		indicator.markReady();
+		assertTrue(indicator.isReady());
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/file/ExifStripperTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/file/ExifStripperTest.java
@@ -1,0 +1,65 @@
+package pt.isep.desofs.vendnet.infrastructure.file;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExifStripperTest {
+
+	private ExifStripper exifStripper;
+
+	@BeforeEach
+	void setUp() {
+		exifStripper = new ExifStripper();
+	}
+
+	@Test
+	void stripExif_png_shouldReturnStrippedImage() throws IOException {
+		BufferedImage img = new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = img.createGraphics();
+		g.setColor(Color.RED);
+		g.fillRect(0, 0, 10, 10);
+		g.dispose();
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(img, "png", baos);
+		byte[] original = baos.toByteArray();
+
+		byte[] result = exifStripper.stripExif(original, "png");
+		assertNotNull(result);
+		assertTrue(result.length > 0);
+	}
+
+	@Test
+	void stripExif_jpeg_shouldReturnStrippedImage() throws IOException {
+		BufferedImage img = new BufferedImage(10, 10, BufferedImage.TYPE_INT_RGB);
+		Graphics2D g = img.createGraphics();
+		g.setColor(Color.BLUE);
+		g.fillRect(0, 0, 10, 10);
+		g.dispose();
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(img, "jpeg", baos);
+		byte[] original = baos.toByteArray();
+
+		byte[] result = exifStripper.stripExif(original, "jpeg");
+		assertNotNull(result);
+		assertTrue(result.length > 0);
+	}
+
+	@Test
+	void stripExif_invalidImage_shouldReturnOriginal() {
+		byte[] invalid = "not an image".getBytes();
+		byte[] result = exifStripper.stripExif(invalid, "png");
+		assertArrayEquals(invalid, result);
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/file/FileValidationServiceImplFileTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/file/FileValidationServiceImplFileTest.java
@@ -1,0 +1,59 @@
+package pt.isep.desofs.vendnet.infrastructure.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+class FileValidationServiceImplFileTest {
+
+	private FileValidationServiceImpl validator;
+
+	@BeforeEach
+	void setUp() {
+		validator = new FileValidationServiceImpl();
+	}
+
+	@Test
+	void validate_jpegFile_withValidContentType_shouldNotThrow() {
+		byte[] jpegBytes = createMinimalJpeg();
+		MockMultipartFile file = new MockMultipartFile("image", "photo.jpg", "image/jpeg", jpegBytes);
+	}
+
+	@Test
+	void validate_fileWithInvalidExtension_shouldThrow() {
+		byte[] content = "not an image".getBytes();
+		MockMultipartFile file = new MockMultipartFile("file", "malware.exe", "image/jpeg", content);
+		assertThrows(IllegalArgumentException.class, () -> validator.validate(file));
+	}
+
+	@Test
+	void validate_fileWithInvalidContentType_shouldThrow() {
+		byte[] content = "not an image".getBytes();
+		MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "application/pdf", content);
+		assertThrows(IllegalArgumentException.class, () -> validator.validate(file));
+	}
+
+	@Test
+	void computeChecksum_shouldReturn64CharHex() {
+		String checksum = validator.computeChecksum("test data".getBytes());
+		assertEquals(64, checksum.length());
+	}
+
+	@Test
+	void computeChecksum_sameInput_sameOutput() {
+		byte[] data = "consistent".getBytes();
+		assertEquals(validator.computeChecksum(data), validator.computeChecksum(data));
+	}
+
+	private byte[] createMinimalJpeg() {
+		return new byte[] {
+			(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+			0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+			0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+			(byte) 0xFF, (byte) 0xD9
+		};
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/file/FileValidationServiceImplTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/file/FileValidationServiceImplTest.java
@@ -1,0 +1,106 @@
+package pt.isep.desofs.vendnet.infrastructure.file;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+class FileValidationServiceImplTest {
+
+	private FileValidationServiceImpl validator;
+
+	@BeforeEach
+	void setUp() {
+		validator = new FileValidationServiceImpl();
+	}
+
+	@Test
+	void validate_nullFile_shouldThrow() {
+		assertThrows(IllegalArgumentException.class, () -> validator.validate(null));
+	}
+
+	@Test
+	void validate_emptyFile_shouldThrow() {
+		MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", new byte[0]);
+		assertThrows(IllegalArgumentException.class, () -> validator.validate(file));
+	}
+
+	@Test
+	void validate_fileTooLarge_shouldThrow() {
+		byte[] largeContent = new byte[6 * 1024 * 1024];
+		MockMultipartFile file = new MockMultipartFile("file", "test.jpg", "image/jpeg", largeContent);
+		assertThrows(IllegalArgumentException.class, () -> validator.validate(file));
+	}
+
+	@Test
+	void validate_invalidContentType_shouldThrow() {
+		MockMultipartFile file = new MockMultipartFile("file", "test.exe", "application/octet-stream", "data".getBytes());
+		assertThrows(IllegalArgumentException.class, () -> validator.validate(file));
+	}
+
+	@Test
+	void validate_invalidExtension_shouldThrow() {
+		MockMultipartFile file = new MockMultipartFile("file", "test.exe", "image/jpeg", "data".getBytes());
+		assertThrows(IllegalArgumentException.class, () -> validator.validate(file));
+	}
+
+	@Test
+	void isAllowedContentType_jpeg_shouldReturnTrue() {
+		assertTrue(validator.isAllowedContentType("image/jpeg"));
+	}
+
+	@Test
+	void isAllowedContentType_png_shouldReturnTrue() {
+		assertTrue(validator.isAllowedContentType("image/png"));
+	}
+
+	@Test
+	void isAllowedContentType_webp_shouldReturnTrue() {
+		assertTrue(validator.isAllowedContentType("image/webp"));
+	}
+
+	@Test
+	void isAllowedContentType_null_shouldReturnFalse() {
+		assertFalse(validator.isAllowedContentType(null));
+	}
+
+	@Test
+	void isAllowedContentType_pdf_shouldReturnFalse() {
+		assertFalse(validator.isAllowedContentType("application/pdf"));
+	}
+
+	@Test
+	void hasValidMagicBytes_jpeg_shouldReturnTrue() {
+		byte[] jpegBytes = new byte[] {(byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10};
+		assertTrue(validator.hasValidMagicBytes(jpegBytes));
+	}
+
+	@Test
+	void hasValidMagicBytes_invalid_shouldReturnFalse() {
+		byte[] invalid = "not an image".getBytes();
+		assertFalse(validator.hasValidMagicBytes(invalid));
+	}
+
+	@Test
+	void computeChecksum_shouldReturnHexSha256() {
+		byte[] data = "hello world".getBytes();
+		String checksum = validator.computeChecksum(data);
+		assertEquals(64, checksum.length());
+		assertTrue(checksum.matches("[0-9a-f]+"));
+	}
+
+	@Test
+	void computeChecksum_shouldBeDeterministic() {
+		byte[] data = "hello world".getBytes();
+		String checksum1 = validator.computeChecksum(data);
+		String checksum2 = validator.computeChecksum(data);
+		assertEquals(checksum1, checksum2);
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/logging/AuditLoggerTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/logging/AuditLoggerTest.java
@@ -1,0 +1,25 @@
+package pt.isep.desofs.vendnet.infrastructure.logging;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+class AuditLoggerTest {
+
+	private final AuditLogger auditLogger = new AuditLogger();
+
+	@Test
+	void log_shouldNotThrow() {
+		assertDoesNotThrow(() -> auditLogger.log("LOGIN", "admin@vendnet.io", "AUTHENTICATE", "/api/auth/login", "SUCCESS", "User logged in"));
+	}
+
+	@Test
+	void log_withNullDetails_shouldNotThrow() {
+		assertDoesNotThrow(() -> auditLogger.log("LOGIN", "admin@vendnet.io", "AUTHENTICATE", "/api/auth/login", "SUCCESS", null));
+	}
+
+	@Test
+	void log_withEmptyStrings_shouldNotThrow() {
+		assertDoesNotThrow(() -> auditLogger.log("", "", "", "", "", ""));
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/os/PathValidatorImplTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/os/PathValidatorImplTest.java
@@ -1,0 +1,54 @@
+package pt.isep.desofs.vendnet.infrastructure.os;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PathValidatorImplTest {
+
+	private final PathValidatorImpl validator = new PathValidatorImpl();
+
+	@Test
+	void isValidPath_childDirectory_shouldReturnTrue(@TempDir Path tempDir) throws IOException {
+		Path child = tempDir.resolve("subdir");
+		Files.createDirectories(child);
+		assertTrue(validator.isValidPath(child, tempDir));
+	}
+
+	@Test
+	void isValidPath_sameDirectory_shouldReturnTrue(@TempDir Path tempDir) {
+		assertTrue(validator.isValidPath(tempDir, tempDir));
+	}
+
+	@Test
+	void isValidPath_outsideDirectory_shouldReturnFalse(@TempDir Path tempDir) {
+		Path outside = Path.of("/etc/passwd");
+		assertFalse(validator.isValidPath(outside, tempDir));
+	}
+
+	@Test
+	void containsSymlink_shouldDetectSymlink(@TempDir Path tempDir) throws IOException {
+		Path target = tempDir.resolve("target");
+		Files.createDirectory(target);
+		Path link = tempDir.resolve("link");
+		try {
+			Files.createSymbolicLink(link, target);
+			assertTrue(validator.containsSymlink(link));
+		} catch (UnsupportedOperationException e) {
+		}
+	}
+
+	@Test
+	void containsSymlink_regularFile_shouldReturnFalse(@TempDir Path tempDir) throws IOException {
+		Path regularFile = tempDir.resolve("regular.txt");
+		Files.writeString(regularFile, "test");
+		assertFalse(validator.containsSymlink(regularFile));
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/os/ReportDirectoryServiceImplTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/os/ReportDirectoryServiceImplTest.java
@@ -1,0 +1,43 @@
+package pt.isep.desofs.vendnet.infrastructure.os;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReportDirectoryServiceImplTest {
+
+	@Mock private PathValidator pathValidator;
+
+	private ReportDirectoryServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		service = new ReportDirectoryServiceImpl(pathValidator);
+		org.springframework.test.util.ReflectionTestUtils.setField(service, "vendnetRoot", "/var/vendnet");
+	}
+
+	@Test
+	void createReportDirectory_invalidType_shouldThrow() {
+		assertThrows(IllegalArgumentException.class, () -> service.createReportDirectory("invalid"));
+	}
+
+	@Test
+	void createReportDirectory_pathTraversal_type_shouldThrow() {
+		assertThrows(IllegalArgumentException.class, () -> service.createReportDirectory("../../etc"));
+	}
+
+	@Test
+	void createReportDirectory_validType_sales_shouldContainPath() {
+		when(pathValidator.isValidPath(any(), any())).thenReturn(true);
+		String result = service.createReportDirectory("sales");
+		assertEquals("/var/vendnet/reports/sales", result.substring(0, "/var/vendnet/reports/sales".length()));
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/os/ReportDirectoryServiceImplTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/os/ReportDirectoryServiceImplTest.java
@@ -1,27 +1,38 @@
 package pt.isep.desofs.vendnet.infrastructure.os;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ReportDirectoryServiceImplTest {
 
+	@TempDir
+	Path tempDir;
+
 	@Mock private PathValidator pathValidator;
 
 	private ReportDirectoryServiceImpl service;
 
 	@BeforeEach
-	void setUp() {
+	void setUp() throws IOException {
 		service = new ReportDirectoryServiceImpl(pathValidator);
-		org.springframework.test.util.ReflectionTestUtils.setField(service, "vendnetRoot", "/var/vendnet");
+		Path vendnetRoot = tempDir.resolve("vendnet");
+		Files.createDirectories(vendnetRoot);
+		org.springframework.test.util.ReflectionTestUtils.setField(service, "vendnetRoot", vendnetRoot.toString());
 	}
 
 	@Test
@@ -35,9 +46,27 @@ class ReportDirectoryServiceImplTest {
 	}
 
 	@Test
-	void createReportDirectory_validType_sales_shouldContainPath() {
+	void createReportDirectory_sales_shouldCreateDir() {
 		when(pathValidator.isValidPath(any(), any())).thenReturn(true);
 		String result = service.createReportDirectory("sales");
-		assertEquals("/var/vendnet/reports/sales", result.substring(0, "/var/vendnet/reports/sales".length()));
+		assertTrue(result.contains("sales"));
+		assertTrue(Files.exists(Path.of(result)));
+	}
+
+	@Test
+	void createReportDirectory_inventory_shouldCreateDir() {
+		when(pathValidator.isValidPath(any(), any())).thenReturn(true);
+		String result = service.createReportDirectory("inventory");
+		assertTrue(result.contains("inventory"));
+		assertTrue(Files.exists(Path.of(result)));
+	}
+
+	@Test
+	void createReportDirectory_idempotent_shouldNotThrow() {
+		when(pathValidator.isValidPath(any(), any())).thenReturn(true);
+		assertDoesNotThrow(() -> {
+			service.createReportDirectory("sales");
+			service.createReportDirectory("sales");
+		});
 	}
 }

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/payment/PaymentGatewayServiceImplTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/payment/PaymentGatewayServiceImplTest.java
@@ -1,0 +1,82 @@
+package pt.isep.desofs.vendnet.infrastructure.payment;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PaymentGatewayServiceImplTest {
+
+	private PaymentGatewayServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		service = new PaymentGatewayServiceImpl();
+		ReflectionTestUtils.setField(service, "webhookSecret", "test-secret-key");
+	}
+
+	@Test
+	void authorizePayment_validToken_shouldNotThrow() {
+		assertDoesNotThrow(() -> service.authorizePayment("tok_12345", new java.math.BigDecimal("10.00")));
+	}
+
+	@Test
+	void authorizePayment_nullToken_shouldThrow() {
+		assertThrows(RuntimeException.class, () -> service.authorizePayment(null, new java.math.BigDecimal("10.00")));
+	}
+
+	@Test
+	void authorizePayment_blankToken_shouldThrow() {
+		assertThrows(RuntimeException.class, () -> service.authorizePayment("   ", new java.math.BigDecimal("10.00")));
+	}
+
+	@Test
+	void verifyWebhookSignature_valid_shouldReturnTrue() {
+		String body = "{\"event\":\"payment.completed\"}";
+		String signature = computeHmac(body, "test-secret-key");
+		assertTrue(service.verifyWebhookSignature(body, signature));
+	}
+
+	@Test
+	void verifyWebhookSignature_invalid_shouldReturnFalse() {
+		String body = "{\"event\":\"payment.completed\"}";
+		assertFalse(service.verifyWebhookSignature(body, "wrong-signature"));
+	}
+
+	@Test
+	void verifyWebhookSignature_nullSignature_shouldReturnFalse() {
+		assertFalse(service.verifyWebhookSignature("body", null));
+	}
+
+	@Test
+	void parseWebhook_validJson_shouldReturnMap() {
+		String body = "{\"event\":\"payment.completed\",\"status\":\"success\"}";
+		Map<String, String> result = service.parseWebhook(body);
+		assertEquals("payment.completed", result.get("event"));
+		assertEquals("success", result.get("status"));
+	}
+
+	@Test
+	void parseWebhook_invalidJson_shouldReturnEmptyMap() {
+		Map<String, String> result = service.parseWebhook("not json");
+		assertTrue(result.isEmpty());
+	}
+
+	private String computeHmac(String data, String key) {
+		try {
+			javax.crypto.Mac mac = javax.crypto.Mac.getInstance("HmacSHA256");
+			javax.crypto.spec.SecretKeySpec keySpec = new javax.crypto.spec.SecretKeySpec(key.getBytes(), "HmacSHA256");
+			mac.init(keySpec);
+			byte[] hash = mac.doFinal(data.getBytes());
+			return java.util.HexFormat.of().formatHex(hash);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/CorrelationIdFilterTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/CorrelationIdFilterTest.java
@@ -1,0 +1,58 @@
+package pt.isep.desofs.vendnet.infrastructure.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class CorrelationIdFilterTest {
+
+	private CorrelationIdFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		filter = new CorrelationIdFilter();
+		MDC.clear();
+	}
+
+	@Test
+	void doFilter_withCorrelationId_shouldUseProvidedId() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Correlation-Id", "test-correlation-123");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertEquals("test-correlation-123", response.getHeader("X-Correlation-Id"));
+	}
+
+	@Test
+	void doFilter_withoutCorrelationId_shouldGenerateOne() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertNotNull(response.getHeader("X-Correlation-Id"));
+	}
+
+	@Test
+	void doFilter_blankCorrelationId_shouldGenerateOne() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Correlation-Id", "   ");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertNotNull(response.getHeader("X-Correlation-Id"));
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/IastTaintTrackingFilterTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/IastTaintTrackingFilterTest.java
@@ -1,0 +1,100 @@
+package pt.isep.desofs.vendnet.infrastructure.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import jakarta.servlet.FilterChain;
+
+class IastTaintTrackingFilterTest {
+
+	private IastTaintTrackingFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		filter = new IastTaintTrackingFilter();
+		IastTaintTrackingFilter.clearDetectedFlows();
+		IastTaintTrackingFilter.clearConfirmedExploitableFlows();
+	}
+
+	@AfterEach
+	void tearDown() {
+		IastTaintTrackingFilter.clearDetectedFlows();
+		IastTaintTrackingFilter.clearConfirmedExploitableFlows();
+	}
+
+	@Test
+	void doFilter_cleanRequest_shouldNotDetectFlows() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI("/api/products");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = (req, resp) -> {};
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertTrue(IastTaintTrackingFilter.getDetectedFlows().isEmpty());
+		assertTrue(IastTaintTrackingFilter.getConfirmedExploitableFlows().isEmpty());
+	}
+
+	@Test
+	void doFilter_sqlInjection_shouldDetectTaintFlow() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI("/api/products");
+		request.addParameter("q", "' OR 1=1");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = (req, resp) -> {};
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertFalse(IastTaintTrackingFilter.getDetectedFlows().isEmpty());
+	}
+
+	@Test
+	void doFilter_pathTraversal_shouldDetectTaintFlow() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI("/api/files/../../etc/passwd");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = (req, resp) -> {};
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		Map<String, List<IastTaintTrackingFilter.TaintFlow>> flows = IastTaintTrackingFilter.getDetectedFlows();
+		assertFalse(flows.isEmpty());
+	}
+
+	@Test
+	void getDetectedFlows_shouldReturnUnmodifiableMap() {
+		Map<String, List<IastTaintTrackingFilter.TaintFlow>> flows = IastTaintTrackingFilter.getDetectedFlows();
+		assertTrue(flows.isEmpty());
+	}
+
+	@Test
+	void clearDetectedFlows_shouldClearAllFlows() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI("/api/products");
+		request.addParameter("q", "' OR 1=1");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = (req, resp) -> {};
+
+		filter.doFilterInternal(request, response, filterChain);
+		assertFalse(IastTaintTrackingFilter.getDetectedFlows().isEmpty());
+
+		IastTaintTrackingFilter.clearDetectedFlows();
+		assertTrue(IastTaintTrackingFilter.getDetectedFlows().isEmpty());
+	}
+
+	@Test
+	void taintFlow_toString_shouldContainType() {
+		IastTaintTrackingFilter.TaintFlow flow = new IastTaintTrackingFilter.TaintFlow(
+				"SQL_INJECTION", "param q", "query");
+		String str = flow.toString();
+		assertTrue(str.contains("SQL_INJECTION"));
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/JwtAuthenticationFilterTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,135 @@
+package pt.isep.desofs.vendnet.infrastructure.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import pt.isep.desofs.vendnet.application.service.JwtService;
+import pt.isep.desofs.vendnet.domain.model.user.AccountStatus;
+import pt.isep.desofs.vendnet.domain.model.user.Role;
+import pt.isep.desofs.vendnet.domain.model.user.User;
+import pt.isep.desofs.vendnet.domain.repository.UserRepository;
+
+class JwtAuthenticationFilterTest {
+
+	private JwtAuthenticationFilter filter;
+	private JwtService jwtService;
+	private UserRepository userRepository;
+
+	@BeforeEach
+	void setUp() {
+		jwtService = mock(JwtService.class);
+		userRepository = mock(UserRepository.class);
+		filter = new JwtAuthenticationFilter(jwtService, userRepository);
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void doFilter_noAuthHeader_shouldContinue() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	@Test
+	void doFilter_invalidToken_shouldContinue() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer invalid-token");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		when(jwtService.isTokenValid("invalid-token")).thenReturn(false);
+
+		filter.doFilterInternal(request, response, filterChain);
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	@Test
+	void doFilter_validToken_shouldAuthenticate() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer valid-token");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		User user = User.builder()
+				.id(1L).email("admin@vendnet.io").role(Role.ROLE_ADMINISTRATOR)
+				.accountStatus(AccountStatus.ACTIVE).build();
+
+		when(jwtService.isTokenValid("valid-token")).thenReturn(true);
+		when(jwtService.extractEmail("valid-token")).thenReturn("admin@vendnet.io");
+		when(userRepository.findByEmail("admin@vendnet.io")).thenReturn(Optional.of(user));
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+		assertEquals("admin@vendnet.io", SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+	}
+
+	@Test
+	void doFilter_suspendedUser_shouldNotAuthenticate() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer valid-token");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		User user = User.builder()
+				.id(1L).email("suspended@vendnet.io").role(Role.ROLE_CUSTOMER)
+				.accountStatus(AccountStatus.SUSPENDED).build();
+
+		when(jwtService.isTokenValid("valid-token")).thenReturn(true);
+		when(jwtService.extractEmail("valid-token")).thenReturn("suspended@vendnet.io");
+		when(userRepository.findByEmail("suspended@vendnet.io")).thenReturn(Optional.of(user));
+
+		filter.doFilterInternal(request, response, filterChain);
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	@Test
+	void doFilter_lockedUser_shouldNotAuthenticate() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer valid-token");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		User user = User.builder()
+				.id(1L).email("locked@vendnet.io").role(Role.ROLE_CUSTOMER)
+				.accountStatus(AccountStatus.LOCKED).build();
+
+		when(jwtService.isTokenValid("valid-token")).thenReturn(true);
+		when(jwtService.extractEmail("valid-token")).thenReturn("locked@vendnet.io");
+		when(userRepository.findByEmail("locked@vendnet.io")).thenReturn(Optional.of(user));
+
+		filter.doFilterInternal(request, response, filterChain);
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	@Test
+	void doFilter_userNotFound_shouldNotAuthenticate() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Authorization", "Bearer valid-token");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		when(jwtService.isTokenValid("valid-token")).thenReturn(true);
+		when(jwtService.extractEmail("valid-token")).thenReturn("unknown@vendnet.io");
+		when(userRepository.findByEmail("unknown@vendnet.io")).thenReturn(Optional.empty());
+
+		filter.doFilterInternal(request, response, filterChain);
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/TaintAwareHttpServletResponseWrapperTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/TaintAwareHttpServletResponseWrapperTest.java
@@ -1,0 +1,53 @@
+package pt.isep.desofs.vendnet.infrastructure.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class TaintAwareHttpServletResponseWrapperTest {
+
+	private MockHttpServletResponse response;
+	private TaintAwareHttpServletResponseWrapper wrapper;
+
+	@BeforeEach
+	void setUp() {
+		response = new MockHttpServletResponse();
+		wrapper = new TaintAwareHttpServletResponseWrapper(response);
+	}
+
+	@Test
+	void getOutputStream_shouldWriteBytes() throws IOException {
+		wrapper.getOutputStream().write(65);
+		assertEquals(1, response.getContentAsByteArray().length);
+	}
+
+	@Test
+	void getWriter_shouldWriteContent() throws IOException {
+		wrapper.getWriter().write("hello");
+		wrapper.getWriter().flush();
+		assertEquals("hello", response.getContentAsString());
+	}
+
+	@Test
+	void getOutputStream_calledTwice_shouldReturnSameStream() throws IOException {
+		var os1 = wrapper.getOutputStream();
+		var os2 = wrapper.getOutputStream();
+		assertEquals(os1, os2);
+	}
+
+	@Test
+	void getWriter_afterGetOutputStream_shouldThrow() {
+		wrapper.getOutputStream();
+		assertThrows(IllegalStateException.class, () -> wrapper.getWriter());
+	}
+
+	@Test
+	void getOutputStream_afterGetWriter_shouldThrow() throws IOException {
+		wrapper.getWriter();
+		assertThrows(IllegalStateException.class, () -> wrapper.getOutputStream());
+	}
+}

--- a/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/X509MachineAuthenticationFilterTest.java
+++ b/vendnet/src/test/java/pt/isep/desofs/vendnet/infrastructure/security/X509MachineAuthenticationFilterTest.java
@@ -1,0 +1,72 @@
+package pt.isep.desofs.vendnet.infrastructure.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import java.security.cert.X509Certificate;
+import javax.security.auth.x500.X500Principal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class X509MachineAuthenticationFilterTest {
+
+	private X509MachineAuthenticationFilter filter;
+
+	@BeforeEach
+	void setUp() {
+		filter = new X509MachineAuthenticationFilter();
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void doFilter_withValidCert_shouldSetAuthentication() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		X509Certificate cert = mock(X509Certificate.class);
+		X500Principal principal = new X500Principal("CN=VM-001,O=VendNet,C=PT");
+		when(cert.getSubjectX500Principal()).thenReturn(principal);
+		request.setAttribute("jakarta.servlet.request.X509Certificate", new X509Certificate[]{cert});
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertNotNull(SecurityContextHolder.getContext().getAuthentication());
+		assertEquals("VM-001", SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+	}
+
+	@Test
+	void doFilter_withoutCert_shouldContinue() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertNull(SecurityContextHolder.getContext().getAuthentication());
+	}
+
+	@Test
+	void doFilter_certWithoutCN_shouldReturn403() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = mock(FilterChain.class);
+
+		X509Certificate cert = mock(X509Certificate.class);
+		X500Principal principal = new X500Principal("O=VendNet,C=PT");
+		when(cert.getSubjectX500Principal()).thenReturn(principal);
+		request.setAttribute("jakarta.servlet.request.X509Certificate", new X509Certificate[]{cert});
+
+		filter.doFilterInternal(request, response, filterChain);
+
+		assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+	}
+}


### PR DESCRIPTION
The ${{ github.sha::7 }} syntax is bash substring, not valid GitHub Actions expression syntax. The BUILD_TAG env var was unused in the deploy script anyway (image tag comes from docker-build), so remove it entirely.

Fixes actionlint expression error on line 548.