### PR TITLE
Set REMOTE_SSH_PORT to 22

### DIFF
--- a/.github/workflows/vendnet-ci-cd.yml
+++ b/.github/workflows/vendnet-ci-cd.yml
@@ -80,7 +80,7 @@ env:
   REGISTRY: ghcr.io
   # Remote server (DEI ISEP private cloud)
   REMOTE_HOST: vs427.dei.isep.ipp.pt
-  REMOTE_SSH_PORT: '2222'
+  REMOTE_SSH_PORT: '22'
   REMOTE_USER: root
   # Ports per environment (public-facing)
   DEV_PORT: '8280'


### PR DESCRIPTION
Update the CI/CD workflow to use the standard SSH port by changing REMOTE_SSH_PORT from '2222' to '22' in .github/workflows/vendnet-ci-cd.yml. This aligns the runner with the remote host's expected SSH port and resolves connection issues when the default port is used.