### PR TITLE
Remove stale MySQL container before start

### DIFF
--- a/scripts/blue-green-deploy.sh
+++ b/scripts/blue-green-deploy.sh
@@ -319,6 +319,12 @@ ensure_mysql_running() {
         return 0
     fi
 
+    # Remove stopped/conflicting container from previous failed deploy
+    if docker inspect "$mysql_name" >/dev/null 2>&1; then
+        log "  ${RECYCLE} Removing stale MySQL container: ${mysql_name}"
+        docker rm "$mysql_name" 2>/dev/null || true
+    fi
+
     log "${PACKAGE} Starting MySQL container: ${mysql_name}"
 
     # Ensure Docker network exists


### PR DESCRIPTION
In ensure_mysql_running (scripts/blue-green-deploy.sh), detect and remove any existing/stopped MySQL container from previous failed deploys before starting a new container. Logs the removal and uses a tolerant docker rm (|| true) to avoid blocking the deploy, preventing name conflicts when launching MySQL.