### PR TITLE
CI: Link Docker Hub image & trim artifacts section

### DIFF
--- a/.github/workflows/vendnet-ci-cd.yml
+++ b/.github/workflows/vendnet-ci-cd.yml
@@ -1519,22 +1519,12 @@ jobs:
               echo "| PRODUCTION  | ⏭️ Not deployed | — |"
             fi
             echo ""
-            echo "### 📦 Artifacts & Links"
-            echo ""
-            if [ -n "${{ secrets.SONAR_HOST_URL }}" ]; then
-              echo "🔗 [SonarQube Dashboard](${{ secrets.SONAR_HOST_URL }}/dashboard?id=vendnet)"
-            fi
-            echo ""
-            echo "🔗 [JaCoCo Coverage Report](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) *(download artifact: jacoco-report)*"
-            echo "🔗 [ZAP DAST Reports](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) *(download artifacts: zap-baseline, zap-api-auth)*"
-            echo "🔗 [Unit Test Reports](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) *(download artifact: unit-test-reports)*"
-            echo "🔗 [Integration Test Reports](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) *(download artifact: integration-test-reports)*"
-            echo ""
             echo "### 🐳 Docker Images"
             echo "| Registry | Image |"
             echo "|----------|-------|"
             echo "| **GHCR**      | \`${{ needs.docker-build-push.outputs.image_full }}:${{ needs.setup-context.outputs.image_tag }}\` |"
-            echo "| **Docker Hub**| \`docker.io/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')/vendnet:${{ needs.setup-context.outputs.image_tag }}\` |"
+            DOCKERHUB_REPO="$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+            echo "| **Docker Hub**| [\`${DOCKERHUB_REPO}/vendnet:${{ needs.setup-context.outputs.image_tag }}\`](https://hub.docker.com/r/${DOCKERHUB_REPO}/vendnet) |"
             echo ""
             if [ "${RELEASE}" != "skipped" ]; then
               echo "### 📦 GitHub Release"

--- a/vendnet/sonar-project.properties
+++ b/vendnet/sonar-project.properties
@@ -12,3 +12,7 @@ sonar.junit.reportPaths=target/surefire-reports
 
 sonar.qualitygate.wait=true
 sonar.qualitygate.timeout=300
+
+# Exclude packages from coverage that JaCoCo doesn't enforce thresholds on
+# (mirrors ci-security profile: only domain.* + application.* are gated)
+sonar.coverage.exclusions=api/**,config/**,infrastructure/**,**/VendnetApplication.java


### PR DESCRIPTION
Remove verbose artifact links from the CI job output and make the Docker Hub image entry a clickable link by defining DOCKERHUB_REPO and linking to hub.docker.com. Also update vendnet/sonar-project.properties to exclude api/**, config/**, infrastructure/** and VendnetApplication.java from coverage so JaCoCo/Sonar coverage gating mirrors the CI security profile (only domain.* and application.* are gated).