### PR TITLE
Use hyphen for image and artifact tags

### DIFF
--- a/.github/workflows/vendnet-ci-cd.yml
+++ b/.github/workflows/vendnet-ci-cd.yml
@@ -145,11 +145,11 @@ jobs:
           fi
 
           SHORT_SHA="${GITHUB_SHA::7}"
-          # Semver with build metadata: {version}+{short_sha}
-          IMAGE_TAG="${VERSION}+${SHORT_SHA}"
+          # Semver with build metadata: {version}-{short_sha}
+          IMAGE_TAG="${VERSION}-${SHORT_SHA}"
 
-          # Artifact naming: vendnet-{version}+{short_sha}
-          ARTIFACT_NAME="${APP_NAME}-${VERSION}+${SHORT_SHA}"
+          # Artifact naming: vendnet-{version}-{short_sha}
+          ARTIFACT_NAME="${APP_NAME}-${VERSION}-${SHORT_SHA}"
 
           # Boolean flags for conditional jobs
           if [ "${GITHUB_REF}" = "refs/heads/main" ] || [ "${GITHUB_REF_TYPE}" = "tag" ]; then


### PR DESCRIPTION
Update CI workflow to use a hyphen between version and short SHA instead of a plus. Adjust IMAGE_TAG and ARTIFACT_NAME formats and relevant comments in .github/workflows/vendnet-ci-cd.yml to produce tags like {version}-{short_sha} and artifact names like {app}-{version}-{short_sha} (standardizes naming and avoids the prior '+' separator).